### PR TITLE
wordpress vip code standards fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 **This plugin is currently in beta. This means there can and probably will be bugs. If you run into anything, please open an issue.**
 
-This is the GitHub mirror of the official JW Player Plugin for Wordpress.
+This is the GitHub mirror of the official JW Player Plugin for WordPress.
 
 ## Plugin User Information.
 
-If you are only interested in using this plugin please visit [this plugin's page on Wordpress plugins site](https://wordpress.org/plugins/jw-player/) for information on how to install and use this plugin. If you're interested in developing or filing bugs, please read on.
+If you are only interested in using this plugin please visit [this plugin's page on WordPress plugins site](https://wordpress.org/plugins/jw-player/) for information on how to install and use this plugin. If you're interested in developing or filing bugs, please read on.
 
 ## Plugin Developer Information.
 
-The official releases of our plugin are hosted on [the official Wordpress Subversion Repository](http://plugins.svn.wordpress.org/jw-player/). We've decided to release this mirror on GitHub for easier development and for better feedback from the plugin's users.
+The official releases of our plugin are hosted on [the official WordPress Subversion Repository](http://plugins.svn.wordpress.org/jw-player/). We've decided to release this mirror on GitHub for easier development and for better feedback from the plugin's users.
 
 We strongly encourage people to make suggestions for enhancing the plugin by making pull-requests. We also encourage users to [report issues](https://github.com/jwplayer/wordpress-plugin/issues/new) with the plugin here on GitHub.
 

--- a/jw-player/include/admin.php
+++ b/jw-player/include/admin.php
@@ -15,7 +15,7 @@ function jwplayer_admin_init() {
 
 // Show the login notice in the admin area if necessary
 function jwplayer_admin_show_login_notice() {
-	if ( isset( $_GET['page'] ) && 'jwplayer_login_page' === sanitize_text_field( $_GET['page'] ) ) {// input var okay
+	if ( isset( $_GET['page'] ) && 'jwplayer_login_page' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) {// input var okay
 		return;
 	} else {
 		$login_url = get_admin_url( null, 'admin.php?page=jwplayer_login_page' );

--- a/jw-player/include/admin.php
+++ b/jw-player/include/admin.php
@@ -48,7 +48,7 @@ function jwplayer_admin_enqueue_scripts( $hook_suffix ) {
 		'post.php',
 		'post-new.php',
 	);
-	if ( ! in_array( $hook_suffix, $load_on_pages ) ) {
+	if ( ! in_array( $hook_suffix, $load_on_pages, true ) ) {
 		return;
 	}
 

--- a/jw-player/include/admin.php
+++ b/jw-player/include/admin.php
@@ -15,7 +15,7 @@ function jwplayer_admin_init() {
 
 // Show the login notice in the admin area if necessary
 function jwplayer_admin_show_login_notice() {
-	if ( isset( $_GET['page'] ) && 'jwplayer_login_page' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) {// input var okay
+	if ( isset( $_GET['page'] ) && 'jwplayer_login_page' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) { // Input var okay
 		return;
 	} else {
 		$login_url = get_admin_url( null, 'admin.php?page=jwplayer_login_page' );

--- a/jw-player/include/admin.php
+++ b/jw-player/include/admin.php
@@ -3,7 +3,7 @@
 // Add the JW Player settings to the media page in the admin panel
 function jwplayer_admin_init() {
 	add_action( 'admin_menu', 'jwplayer_settings_init' );
-	if ( get_option ( 'jwplayer_api_key' ) ) {
+	if ( get_option( 'jwplayer_api_key' ) ) {
 		add_action( 'admin_head-post.php', 'jwplayer_admin_head' );
 		add_action( 'admin_head-post-new.php', 'jwplayer_admin_head' );
 		add_action( 'admin_head-media-upload-popup', 'jwplayer_admin_head' );

--- a/jw-player/include/ajax.php
+++ b/jw-player/include/ajax.php
@@ -4,7 +4,7 @@
 // utlizes proxy.php
 add_action( 'wp_ajax_jwplayer', function() {
 	if ( isset( $_GET['method'] ) ) {//input var okay
-		if ( 'upload_ready' === sanitize_text_field( wp_unslash( $_GET['method'] ) ) ) {//input var okay
+		if ( 'upload_ready' === sanitize_text_field( wp_unslash( $_GET['method'] ) ) ) { // Input var okay
 			echo '{"status" : "ok"}';
 		} else {
 			jwplayer_proxy();

--- a/jw-player/include/ajax.php
+++ b/jw-player/include/ajax.php
@@ -2,14 +2,13 @@
 
 // ajax calls for the jwplayer plugin
 // utlizes proxy.php
-add_action( 'wp_ajax_jwplayer', function(){
-		if ( isset( $_GET['method'] ) ){//input var okay
-			if ( 'upload_ready' === sanitize_text_field( $_GET['method'] ) ){//input var okay
-				echo '{"status" : "ok"}';
-			}
-			else {
-				jwplayer_proxy();
-			}
+add_action( 'wp_ajax_jwplayer', function() {
+	if ( isset( $_GET['method'] ) ) {//input var okay
+		if ( 'upload_ready' === sanitize_text_field( $_GET['method'] ) ) {//input var okay
+			echo '{"status" : "ok"}';
+		} else {
+			jwplayer_proxy();
 		}
-		die();
+	}
+	die();
 } );

--- a/jw-player/include/ajax.php
+++ b/jw-player/include/ajax.php
@@ -4,7 +4,7 @@
 // utlizes proxy.php
 add_action( 'wp_ajax_jwplayer', function() {
 	if ( isset( $_GET['method'] ) ) {//input var okay
-		if ( 'upload_ready' === sanitize_text_field( $_GET['method'] ) ) {//input var okay
+		if ( 'upload_ready' === sanitize_text_field( wp_unslash( $_GET['method'] ) ) ) {//input var okay
 			echo '{"status" : "ok"}';
 		} else {
 			jwplayer_proxy();

--- a/jw-player/include/api.php
+++ b/jw-player/include/api.php
@@ -1,8 +1,8 @@
 <?php
 
-function jwplayer_api_call( $method, $params = array() ){
+function jwplayer_api_call( $method, $params = array() ) {
 	$api = jwplayer_api_get_instance();
-	foreach ($params as $key => $value) {
+	foreach ( $params as $key => $value ) {
 		if ( null === $value ) {
 			unset( $params[ $key ] );
 		}
@@ -37,9 +37,8 @@ function jwplayer_api_get_instance() {
 
 	if ( 8 === strlen( $api_key ) && 24 === strlen( $api_secret ) ) {
 		return new JWPlayer_api( $api_key, $api_secret );
-	}
-	else {
-		jwplayer_log( 'API: Could not instantiate.');
+	} else {
+		jwplayer_log( 'API: Could not instantiate.' );
 		return null;
 	}
 }

--- a/jw-player/include/import.php
+++ b/jw-player/include/import.php
@@ -1,11 +1,11 @@
 <?php
 
 function jwplayer_import_check_and_init() {
-	if ( get_option ( 'jwplayer_api_key' ) && get_option ( 'jwp6_plugin_version' ) && ! get_option ( 'jwplayer_import_done' ) ) {
+	if ( get_option( 'jwplayer_api_key' ) && get_option( 'jwp6_plugin_version' ) && ! get_option( 'jwplayer_import_done' ) ) {
 		$nr_of_players = jwplayer_import_nr_of_players();
 		$nr_of_playlists = jwplayer_import_nr_of_playlists();
-		$botr_active = is_plugin_active('bits-on-the-run/bitsontherun.php');
-		$jwp_active = is_plugin_active('jw-player-plugin-for-wordpress/jwplayermodule.php');
+		$botr_active = is_plugin_active( 'bits-on-the-run/bitsontherun.php' );
+		$jwp_active = is_plugin_active( 'jw-player-plugin-for-wordpress/jwplayermodule.php' );
 		$vip_active = false;  // is_plugin_active('????????');
 		if ( $nr_of_players || $nr_of_playlists ) {
 			add_action( 'admin_notices', 'jwplayer_import_legacy_notice' );
@@ -33,7 +33,7 @@ function jwplayer_import_check_and_init() {
 function jwplayer_import_legacy_notice() {
 	if ( isset( $_GET['page'] ) && 'jwplayer_import' === sanitize_text_field( $_GET['page'] ) ) {
 		return;
-	} elseif ( get_option ( 'jwplayer_api_key' ) ) {
+	} elseif ( get_option( 'jwplayer_api_key' ) ) {
 		$import_url = get_admin_url( null, 'admin.php?page=jwplayer_import' );
 		echo '
 			<div class="update-nag fade">

--- a/jw-player/include/import.php
+++ b/jw-player/include/import.php
@@ -189,7 +189,6 @@ function jwplayer_import_legacy_playlists() {
 		'post_type' => 'jw_playlist',
 		'post_status' => null,
 		'post_parent' => null,
-		'nopaging' => true,
 	);
 	return query_posts( $query_params );
 }

--- a/jw-player/include/import.php
+++ b/jw-player/include/import.php
@@ -31,7 +31,7 @@ function jwplayer_import_check_and_init() {
 }
 
 function jwplayer_import_legacy_notice() {
-	if ( isset( $_GET['page'] ) && 'jwplayer_import' === sanitize_text_field( $_GET['page'] ) ) {
+	if ( isset( $_GET['page'] ) && 'jwplayer_import' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) {
 		return;
 	} elseif ( get_option( 'jwplayer_api_key' ) ) {
 		$import_url = get_admin_url( null, 'admin.php?page=jwplayer_import' );
@@ -53,7 +53,7 @@ function jwplayer_import_legacy_notice() {
 
 function jwplayer_import_disable_notice() {
 	$screen_info = get_current_screen();
-	if ( isset( $_GET['page'] ) && 'jwplayer_import' === sanitize_text_field( $_GET['page'] ) ) {
+	if ( isset( $_GET['page'] ) && 'jwplayer_import' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) {
 		return;
 	} elseif ( 'plugins' === $screen_info->id ) {
 		return;
@@ -68,26 +68,26 @@ function jwplayer_import_disable_notice() {
 					<strong>Note:</strong>
 		';
 		if ( $botr_active && $jwp_active ) {
-			echo "
+			echo '
 					It looks like you have not deactivated the old JW Player and
 					the old JW Platform plugins yet.
-			";
+			';
 		} elseif ( $botr_active ) {
-			echo "
+			echo '
 					It looks like you have not deactivated the old JW Platform plugin yet.
-			";
+			';
 		} elseif ( $jwp_active ) {
-			echo "
+			echo '
 					It looks like you have not deactivated the old JW Player plugin yet.
-			";
+			';
 		}
-		echo "
-						You will need to do that on the <a href='$plugins_url'
-						title='Go to the plugins page'>plugins page</a> (These plugins
+		echo '
+						You will need to do that on the <a href="' . esc_url( $plugins_url ) . '"
+						title="Go to the plugins page">plugins page</a> (These plugins
 						cannot be used at the same time).
 					</p>
 				</div>
-			";
+			';
 	}
 }
 
@@ -189,7 +189,7 @@ function jwplayer_import_legacy_playlists() {
 		'post_type' => 'jw_playlist',
 		'post_status' => null,
 		'post_parent' => null,
-		'nopaging' => true
+		'nopaging' => true,
 	);
 	return query_posts( $query_params );
 }
@@ -210,7 +210,7 @@ function jwplayer_import_skin_list() {
 }
 
 function jwplayer_import_players() {
-	if ( ! current_user_can( 'manage_options') ) {
+	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
 	$player_ids = get_option( 'jwp6_players' );

--- a/jw-player/include/import.php
+++ b/jw-player/include/import.php
@@ -136,17 +136,17 @@ function jwplayer_import_check_redirect() {
 function jwplayer_import_include_players() {
 	$nr = jwplayer_import_nr_of_players();
 	echo '<input name="jwplayer_import_include_players" id="jwplayer_import_include_players" type="checkbox" value="true" /> ';
-	echo "
-		<label for='jwplayer_import_include_players'>
-			Import all player configurations. <strong>($nr from old plugin)</strong>
+	echo '
+		<label for="jwplayer_import_include_players">
+			Import all player configurations. <strong>(' . esc_html( $nr ). ' from old plugin)</strong>
 		</label>
-	";
+	';
 	// TODO: Have URL to support doc explaining the custom shortcode parser.
 	echo '
 		<p class="description">
 			You can always decide to edit or delete these players after the import —
 			they will be in your Players list int he JW Player dashboard, with a
-			"Wordpress" name.
+			"WordPress" name.
 		</p>
 	';
 }
@@ -154,12 +154,12 @@ function jwplayer_import_include_players() {
 function jwplayer_import_include_playlists() {
 	$nr = jwplayer_import_nr_of_playlists();
 	echo '<input name="jwplayer_import_include_playlists" id="jwplayer_import_include_playlists" type="checkbox" value="true" /> ';
-	echo "
-		<label for='jwplayer_import_include_playlists'>
+	echo '
+		<label for="jwplayer_import_include_playlists">
 			Import all playlists and content.
-			<strong>($nr from old plugin)</strong>
+			<strong>(' . esc_html( $nr ). ' from old plugin)</strong>
 		</label>
-	";
+	';
 	// TODO: Have URL to support doc explaining the custom shortcode parser.
 	echo '
 		<p class="description">
@@ -226,7 +226,7 @@ function jwplayer_import_players() {
 			continue;
 		}
 		$params = array(
-			'description' => 'Wordpress imported player',
+			'description' => 'WordPress imported player',
 			'width' => 480,
 			'height' => 270,
 			'aspectratio' => null,
@@ -259,9 +259,9 @@ function jwplayer_import_players() {
 		}
 		// Translate these params into parameters that the API accepts.
 		if ( 'Default and fallback player (unremovable).' === $params['description'] ) {
-			$params['name'] = 'Default Wordpress plugin player';
+			$params['name'] = 'Default WordPress plugin player';
 		} else {
-			$params['name'] = $params['description'] . ' (Imported Wordpress player)';
+			$params['name'] = $params['description'] . ' (Imported WordPress player)';
 		}
 		if ( $params['aspectratio'] ) {
 			$params['responsive'] = true;

--- a/jw-player/include/import.php
+++ b/jw-player/include/import.php
@@ -6,21 +6,21 @@ function jwplayer_import_check_and_init() {
 		$nr_of_playlists = jwplayer_import_nr_of_playlists();
 		$botr_active = is_plugin_active( 'bits-on-the-run/bitsontherun.php' );
 		$jwp_active = is_plugin_active( 'jw-player-plugin-for-wordpress/jwplayermodule.php' );
-		$vip_active = false;  // is_plugin_active('????????');
+		$vip_active = false;  // is_plugin_active( '????????' );
 		if ( $nr_of_players || $nr_of_playlists ) {
 			add_action( 'admin_notices', 'jwplayer_import_legacy_notice' );
 			add_submenu_page( null, 'JW Player Legacy Plugin Import', 'JW Player Import', 'manage_options', 'jwplayer_import', 'jwplayer_import_page' );
 			// add_options_page( null, 'JW Player Import', 'JW Player Import', 'manage_options', 'jwplayer_import_page', 'jwplayer_import_page' );
 			add_settings_section( 'jwplayer_import_section', null, 'jwplayer_import_section_html', 'jwplayer_import' );
 			if ( $nr_of_players ) {
-				add_settings_field( 'jwplayer_import_include_players', 'Import Players', 'jwplayer_import_include_players', 'jwplayer_import', 'jwplayer_import_section');
+				add_settings_field( 'jwplayer_import_include_players', 'Import Players', 'jwplayer_import_include_players', 'jwplayer_import', 'jwplayer_import_section' );
 				register_setting( 'jwplayer_import', 'jwplayer_import_include_players', 'jwplayer_import_players_check' );
 			}
 			if ( $nr_of_playlists ) {
-				add_settings_field( 'jwplayer_import_include_playlists', 'Import Playlists', 'jwplayer_import_include_playlists', 'jwplayer_import', 'jwplayer_import_section');
+				add_settings_field( 'jwplayer_import_include_playlists', 'Import Playlists', 'jwplayer_import_include_playlists', 'jwplayer_import', 'jwplayer_import_section' );
 				register_setting( 'jwplayer_import', 'jwplayer_import_include_playlists', 'jwplayer_import_playlists_check' );
 			}
-		} else if ( $botr_active || $jwp_active || $vip_active ) {
+		} elseif ( $botr_active || $jwp_active || $vip_active ) {
 			add_action( 'admin_notices', 'jwplayer_import_disable_notice' );
 		} else {
 			delete_option( 'jwplayer_import_include_players' );
@@ -55,12 +55,12 @@ function jwplayer_import_disable_notice() {
 	$screen_info = get_current_screen();
 	if ( isset( $_GET['page'] ) && 'jwplayer_import' === sanitize_text_field( $_GET['page'] ) ) {
 		return;
-	} else if ( 'plugins' === $screen_info->id ) {
+	} elseif ( 'plugins' === $screen_info->id ) {
 		return;
 	} else {
-		$botr_active = is_plugin_active('bits-on-the-run/bitsontherun.php');
-		$jwp_active = is_plugin_active('jw-player-plugin-for-wordpress/jwplayermodule.php');
-		$vip_active = false;  // is_plugin_active('????????');
+		$botr_active = is_plugin_active( 'bits-on-the-run/bitsontherun.php' );
+		$jwp_active = is_plugin_active( 'jw-player-plugin-for-wordpress/jwplayermodule.php' );
+		$vip_active = false;  // is_plugin_active( '????????' );
 		$plugins_url = get_admin_url( null, 'plugins.php' );
 		echo '
 			<div class="update-nag fade">
@@ -72,11 +72,11 @@ function jwplayer_import_disable_notice() {
 					It looks like you have not deactivated the old JW Player and
 					the old JW Platform plugins yet.
 			";
-		} else if ( $botr_active ) {
+		} elseif ( $botr_active ) {
 			echo "
 					It looks like you have not deactivated the old JW Platform plugin yet.
 			";
-		} else if ( $jwp_active ) {
+		} elseif ( $jwp_active ) {
 			echo "
 					It looks like you have not deactivated the old JW Player plugin yet.
 			";
@@ -100,7 +100,7 @@ function jwplayer_import_page() {
 	echo '<form method="post" action="options.php">';
 	settings_fields( 'jwplayer_import' );
 	do_settings_sections( 'jwplayer_import' );
-	submit_button('Start Import');
+	submit_button( 'Start Import' );
 	echo '</form>';
 	echo '</div>';
 }
@@ -291,7 +291,7 @@ function jwplayer_import_players() {
 		if ( jwplayer_api_response_ok( $response ) ) {
 			$imported_players[ $player_id ] = $response['player']['key'];
 		} else {
-			jwplayer_log('ERROR CREATING IMPORTED PLAYER');
+			jwplayer_log( 'ERROR CREATING IMPORTED PLAYER' );
 			jwplayer_log( $params, true );
 			jwplayer_log( $response, true );
 		}
@@ -339,13 +339,13 @@ function jwplayer_import_playlists() {
 				);
 				$response = jwplayer_api_call( '/channels/videos/create', $params );
 				if ( ! jwplayer_api_response_ok( $response ) ) {
-					jwplayer_log('ERROR ADDING VIDEO TO PLAYLIST');
+					jwplayer_log( 'ERROR ADDING VIDEO TO PLAYLIST' );
 					jwplayer_log( $params, true );
 					jwplayer_log( $response, true );
 				}
 			}
 		} else {
-			jwplayer_log('ERROR CREATING NEW PLAYLIST');
+			jwplayer_log( 'ERROR CREATING NEW PLAYLIST' );
 			jwplayer_log( $params, true );
 			jwplayer_log( $response, true );
 		}

--- a/jw-player/include/import.php
+++ b/jw-player/include/import.php
@@ -186,10 +186,10 @@ function jwplayer_import_playlists_check( $input ) {
 
 function jwplayer_import_legacy_playlists() {
 	$query_params = array(
-		"post_type" => 'jw_playlist',
-		"post_status" => null,
-		"post_parent" => null,
-		"nopaging" => true,
+		'post_type' => 'jw_playlist',
+		'post_status' => null,
+		'post_parent' => null,
+		'nopaging' => true
 	);
 	return query_posts( $query_params );
 }
@@ -202,7 +202,7 @@ function jwplayer_import_skin_list() {
 	$skins = array();
 	$response = jwplayer_api_call( '/accounts/skins/list', $params );
 	if ( jwplayer_api_response_ok( $response ) ) {
-		foreach ($response['skins'] as $skin) {
+		foreach ( $response['skins'] as $skin ) {
 			$skins[ strtolower( $skin['name'] ) ] = $skin['key'];
 		}
 	}
@@ -266,7 +266,7 @@ function jwplayer_import_players() {
 		if ( $params['aspectratio'] ) {
 			$params['responsive'] = true;
 		} else {
-			unset ( $params['aspectratio'] );
+			unset( $params['aspectratio'] );
 		}
 		if ( $params['skin'] && array_key_exists( $params['skin'], $skins ) ) {
 			$params['skin_key'] = $skins[ $params['skin'] ];
@@ -280,8 +280,15 @@ function jwplayer_import_players() {
 			$params['advertising_tag'] = $params['advertising__tag'];
 		}
 		$delete_params = array(
-			'skin', 'logo__file', 'logo__link', 'logo__position', 'logo__margin',
-			'logo__hide', 'advertising__tag', 'advertising__client', 'description',
+			'skin',
+			'logo__file',
+			'logo__link',
+			'logo__position',
+			'logo__margin',
+			'logo__hide',
+			'advertising__tag',
+			'advertising__client',
+			'description',
 		);
 		foreach ( $delete_params as $delete_param ) {
 			unset( $params[ $delete_param ] );

--- a/jw-player/include/import.php
+++ b/jw-player/include/import.php
@@ -308,7 +308,7 @@ function jwplayer_import_players() {
 }
 
 function jwplayer_import_playlists() {
-	if ( ! current_user_can( 'manage_options') ) {
+	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
 	$imported_playlists = get_option( 'jwplayer_imported_playlists' );
@@ -321,7 +321,7 @@ function jwplayer_import_playlists() {
 		if ( array_key_exists( $playlist->ID, $imported_playlists ) ) {
 			continue;
 		}
-		$media_ids = explode(",", get_post_meta( $playlist->ID, 'jwplayermodule_playlist_items', true ) );
+		$media_ids = explode( ',', get_post_meta( $playlist->ID, 'jwplayermodule_playlist_items', true ) );
 		$media_hashes = array();
 		foreach ( $media_ids as $media_id ) {
 			$media_hash = jwplayer_media_hash( intval( $media_id ) );

--- a/jw-player/include/import.php
+++ b/jw-player/include/import.php
@@ -31,7 +31,7 @@ function jwplayer_import_check_and_init() {
 }
 
 function jwplayer_import_legacy_notice() {
-	if ( isset( $_GET['page'] ) && 'jwplayer_import' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) {
+	if ( isset( $_GET['page'] ) && 'jwplayer_import' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) { // Input var okay
 		return;
 	} elseif ( get_option( 'jwplayer_api_key' ) ) {
 		$import_url = get_admin_url( null, 'admin.php?page=jwplayer_import' );
@@ -53,7 +53,7 @@ function jwplayer_import_legacy_notice() {
 
 function jwplayer_import_disable_notice() {
 	$screen_info = get_current_screen();
-	if ( isset( $_GET['page'] ) && 'jwplayer_import' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) {
+	if ( isset( $_GET['page'] ) && 'jwplayer_import' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) { // Input var okay
 		return;
 	} elseif ( 'plugins' === $screen_info->id ) {
 		return;

--- a/jw-player/include/jwplayer-api.class.php
+++ b/jw-player/include/jwplayer-api.class.php
@@ -25,8 +25,7 @@ class JWPlayer_api {
 		// Determine which HTTP library to use:
 		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
 			$this->_library = 'wpvip';
-		}
-		else {
+		} else {
 			$this->_library = 'wp';
 		}
 	}
@@ -41,11 +40,9 @@ class JWPlayer_api {
 	private function _urlencode( $input ) {
 		if ( is_array( $input ) ) {
 			return array_map( array( '_urlencode' ), $input );
-		}
-		elseif ( is_scalar( $input ) ) {
+		} elseif ( is_scalar( $input ) ) {
 			return str_replace( '+', ' ', str_replace( '%7E', '~', rawurlencode( $input ) ) );
-		}
-		else {
+		} else {
 			return '';
 		}
 	}
@@ -119,8 +116,7 @@ class JWPlayer_api {
 
 		if ( is_wp_error( $response ) ) {
 			$response = 'Error: call to JW Player API failed';
-		}
-		else {
+		} else {
 			$response = wp_remote_retrieve_body( $response );
 		}
 
@@ -145,8 +141,7 @@ class JWPlayer_api {
 
 		if ( is_wp_error( $response ) ) {
 			return $response->get_error_message();
-		}
-		else {
+		} else {
 			return unserialize( $response );
 		}
 	}

--- a/jw-player/include/jwplayer-api.class.php
+++ b/jw-player/include/jwplayer-api.class.php
@@ -94,7 +94,7 @@ class JWPlayer_api {
 
 	// Construct call URL
 	public function call_url( $call, $args = array() ) {
-		$sign = $call != '/accounts/credentials/show';
+		$sign = '/accounts/credentials/show' !== $call;
 		$url = $this->_url . $call . '?' . http_build_query( $this->_args( $args, $sign ), '', '&', PHP_QUERY_RFC3986 );
 		return $url;
 	}

--- a/jw-player/include/jwplayer-api.class.php
+++ b/jw-player/include/jwplayer-api.class.php
@@ -122,7 +122,7 @@ class JWPlayer_api {
 
 		$unserialized_response = unserialize( $response );
 		return $unserialized_response;
-}
+	}
 
 	// Upload a file
 	public function upload( $upload_link = array(), $file_path, $api_format = 'php' ) {

--- a/jw-player/include/jwplayer-api.class.php
+++ b/jw-player/include/jwplayer-api.class.php
@@ -108,8 +108,8 @@ class JWPlayer_api {
 			case 'wpvip':
 				$response = vip_safe_wp_remote_get( $url );
 				break;
-			case 'wp';
-			default;
+			case 'wp':
+			default:
 				$response = wp_remote_get( $url );
 			break;
 		}

--- a/jw-player/include/login.php
+++ b/jw-player/include/login.php
@@ -28,14 +28,14 @@ function jwplayer_login_page() {
 		return;
 	}
 
-	if ( ! isset( $_POST['apikey'], $_POST['apisecret'] ) ) {//input var okay
+	if ( ! isset( $_POST['apikey'], $_POST['apisecret'] ) ) { // Input var okay
 		jwplayer_login_form();
 		return;
 	}
 
 	// Check the nonce (counter XSRF)
 	if ( isset( $_POST['_wpnonce'] ) ) {
-		$nonce = sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) );//input var okay
+		$nonce = sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ); // Input var okay
 		if ( ! wp_verify_nonce( $nonce, 'jwplayer-login-nonce' ) ) {
 			jwplayer_login_print_error( 'Could not verify the form data.' );
 			jwplayer_login_form();
@@ -43,13 +43,9 @@ function jwplayer_login_page() {
 		}
 	}
 
-	if ( isset( $_POST['apikey'] ) ) {
-		$api_key = sanitize_text_field( wp_unslash( $_POST['apikey'] ) );//input var okay
-	}
+	$api_key = isset( $_POST['apikey'] ) ? sanitize_text_field( wp_unslash( $_POST['apikey'] ) ) : false; // Input var okay
 
-	if ( isset( $_POST['apisecret'] ) ) {
-		$api_secret = sanitize_text_field( wp_unslash( $_POST['apisecret'] ) );//input var okay
-	}
+	$api_secret = isset( $_POST['apisecret'] ) ? sanitize_text_field( wp_unslash( $_POST['apisecret'] ) ) : false; // Input var okay
 
 	$api_verified = jwplayer_login_verify_api_key_secret( $api_key, $api_secret );
 
@@ -133,19 +129,17 @@ function jwplayer_login_logout() {
 		return;
 	}
 
-	if ( ! isset( $_POST['logout'] ) ) {//input var okay
+	if ( ! isset( $_POST['logout'] ) ) { // Input var okay
 		jwplayer_login_logout_form();
 		return;
 	}
 
 	// Check the nonce (counter XSRF)
-	if ( isset( $_POST['_wpnonce'] ) ) {
-		$nonce = sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) );//input var okay
-		if ( ! wp_verify_nonce( $nonce, 'jwplayer-logout-nonce' ) ) {
-			jwplayer_login_print_error( 'Could not verify the form data.' );
-			jwplayer_login_logout_form();
-			return;
-		}
+
+	if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'jwplayer-logout-nonce' ) ) { // Input var okay
+		jwplayer_login_print_error( 'Could not verify the form data.' );
+		jwplayer_login_logout_form();
+		return;
 	}
 
 	// Perform the logout.

--- a/jw-player/include/login.php
+++ b/jw-player/include/login.php
@@ -34,9 +34,8 @@ function jwplayer_login_page() {
 	}
 
 	// Check the nonce (counter XSRF)
-	if ( isset( $_POST['_wpnonce'] ) ) {
-		$nonce = sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ); // Input var okay
-		if ( ! wp_verify_nonce( $nonce, 'jwplayer-login-nonce' ) ) {
+	if ( isset( $_POST['_wpnonce'] ) ) { // Input var okay
+		if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'jwplayer-login-nonce' ) ) { // Input var okay
 			jwplayer_login_print_error( 'Could not verify the form data.' );
 			jwplayer_login_form();
 			return;
@@ -136,7 +135,7 @@ function jwplayer_login_logout() {
 
 	// Check the nonce (counter XSRF)
 
-	if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'jwplayer-logout-nonce' ) ) { // Input var okay
+	if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'jwplayer-logout-nonce' ) ) { // Input var okay
 		jwplayer_login_print_error( 'Could not verify the form data.' );
 		jwplayer_login_logout_form();
 		return;

--- a/jw-player/include/login.php
+++ b/jw-player/include/login.php
@@ -4,7 +4,7 @@ function jwplayer_login_init() {
 	add_action( 'admin_menu', 'jwplayer_login_create_pages' );
 }
 
-function jwplayer_login_create_pages(){
+function jwplayer_login_create_pages() {
 	//adds the login page
 	add_submenu_page( null, 'JW Player Authorization', 'JW Player Authorization', 'manage_options', 'jwplayer_login_page', 'jwplayer_login_page' );
 	//adds the logout page
@@ -34,7 +34,7 @@ function jwplayer_login_page() {
 	}
 
 	// Check the nonce (counter XSRF)
-	if ( isset( $_POST['_wpnonce'] ) ){
+	if ( isset( $_POST['_wpnonce'] ) ) {
 		$nonce = sanitize_text_field( $_POST['_wpnonce'] );//input var okay
 		if ( ! wp_verify_nonce( $nonce, 'jwplayer-login-nonce' ) ) {
 			jwplayer_login_print_error( 'Could not verify the form data.' );
@@ -43,11 +43,11 @@ function jwplayer_login_page() {
 		}
 	}
 
-	if ( isset($_POST['apikey']) ){
+	if ( isset($_POST['apikey']) ) {
 		$api_key = sanitize_text_field( $_POST['apikey'] );//input var okay
 	}
 
-	if ( isset($_POST['apisecret']) ){
+	if ( isset($_POST['apisecret']) ) {
 		$api_secret = sanitize_text_field( $_POST['apisecret'] );//input var okay
 	}
 
@@ -56,12 +56,10 @@ function jwplayer_login_page() {
 	if ( null === $api_verified ) {
 		jwplayer_login_print_error( 'Communications with the JW Player API failed. Please try again later.' );
 		jwplayer_login_form();
-	}
-	elseif ( false === $api_verified ) {
+	} elseif ( false === $api_verified ) {
 		jwplayer_login_print_error( 'Your API credentials were not accepted. Please try again.' );
 		jwplayer_login_form();
-	}
-	else {
+	} else {
 		// Perform the login.
 		update_option( 'jwplayer_api_key', $api_key );
 		update_option( 'jwplayer_api_secret', $api_secret );

--- a/jw-player/include/login.php
+++ b/jw-player/include/login.php
@@ -35,7 +35,7 @@ function jwplayer_login_page() {
 
 	// Check the nonce (counter XSRF)
 	if ( isset( $_POST['_wpnonce'] ) ) {
-		$nonce = sanitize_text_field( $_POST['_wpnonce'] );//input var okay
+		$nonce = sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) );//input var okay
 		if ( ! wp_verify_nonce( $nonce, 'jwplayer-login-nonce' ) ) {
 			jwplayer_login_print_error( 'Could not verify the form data.' );
 			jwplayer_login_form();
@@ -44,11 +44,11 @@ function jwplayer_login_page() {
 	}
 
 	if ( isset( $_POST['apikey'] ) ) {
-		$api_key = sanitize_text_field( $_POST['apikey'] );//input var okay
+		$api_key = sanitize_text_field( wp_unslash( $_POST['apikey'] ) );//input var okay
 	}
 
 	if ( isset( $_POST['apisecret'] ) ) {
-		$api_secret = sanitize_text_field( $_POST['apisecret'] );//input var okay
+		$api_secret = sanitize_text_field( wp_unslash( $_POST['apisecret'] ) );//input var okay
 	}
 
 	$api_verified = jwplayer_login_verify_api_key_secret( $api_key, $api_secret );
@@ -140,7 +140,7 @@ function jwplayer_login_logout() {
 
 	// Check the nonce (counter XSRF)
 	if ( isset( $_POST['_wpnonce'] ) ) {
-		$nonce = sanitize_text_field( $_POST['_wpnonce'] );//input var okay
+		$nonce = sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) );//input var okay
 		if ( ! wp_verify_nonce( $nonce, 'jwplayer-logout-nonce' ) ) {
 			jwplayer_login_print_error( 'Could not verify the form data.' );
 			jwplayer_login_logout_form();

--- a/jw-player/include/login.php
+++ b/jw-player/include/login.php
@@ -43,11 +43,11 @@ function jwplayer_login_page() {
 		}
 	}
 
-	if ( isset($_POST['apikey']) ) {
+	if ( isset( $_POST['apikey'] ) ) {
 		$api_key = sanitize_text_field( $_POST['apikey'] );//input var okay
 	}
 
-	if ( isset($_POST['apisecret']) ) {
+	if ( isset( $_POST['apisecret'] ) ) {
 		$api_secret = sanitize_text_field( $_POST['apisecret'] );//input var okay
 	}
 

--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -40,7 +40,7 @@ function jwplayer_media_sync_form_html( $media ) {
 	} else {
 		$html .= "<label for='attachments[$media->ID][jwplayer_media_sync]'>";
 		$html .= "<input type='checkbox' value='sync' name='attachments[$media->ID][jwplayer_media_sync]' />";
-		$html .= "&nbsp;&nbsp;Sync to JW Player";
+		$html .= '&nbsp;&nbsp;Sync to JW Player';
 		$html .= '</label>';
 		$html .= '<p class="description">';
 		$html .= 'Enabling sync to JW Player adds this media file to your JW Player ';

--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -203,7 +203,7 @@ function jwplayer_media_widget_body() {
 	</div>
 	<div class="jwplayer-widget-div" id="jwplayer-video-div">
 		<h4>Video</h4>
-		<p id="jwplayer-account-login-link"><span>Choose content from</span> your <a href="<?php echo JWPLAYER_DASHBOARD; ?>" title="open your dashboard">JW Player Account</a>
+		<p id="jwplayer-account-login-link"><span>Choose content from</span> your <a href="<?php echo esc_url( JWPLAYER_DASHBOARD ); ?>" title="open your dashboard">JW Player Account</a>
 		<ul class="jwplayer-tab-select">
 			<li id="jwplayer-tab-select-choose">Choose</li>
 			<li id="jwplayer-tab-select-add" class="jwplayer-off">Add New</li>

--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -14,10 +14,10 @@ function jwplayer_media_init() {
 
 function jwplayer_media_attachment_fields_to_edit( $form_fields, $media ) {
 	if ( in_array( $media->post_mime_type, unserialize( JWPLAYER_MEDIA_MIME_TYPES ) ) ) {
-		$form_fields["jwplayer_media_sync"] = array(
-			"label" => "JW Player",
-			"input" => "html",
-			"html" => jwplayer_media_sync_form_html( $media )
+		$form_fields['jwplayer_media_sync'] = array(
+			'label' => 'JW Player',
+			'input' => 'html',
+			'html' => jwplayer_media_sync_form_html( $media ),
 		);
 		// $form_fields["jwplayer_media_migrate"] = array (
 		//   "label" => "",
@@ -53,10 +53,10 @@ function jwplayer_media_sync_form_html( $media ) {
 
 
 function jwplayer_media_attachment_fields_to_save( $media, $attachment ) {
-	if ( in_array( $media["post_mime_type"], unserialize( JWPLAYER_MEDIA_MIME_TYPES ) ) ) {
+	if ( in_array( $media['post_mime_type'], unserialize( JWPLAYER_MEDIA_MIME_TYPES ) ) ) {
 		$sync = ( isset( $attachment['jwplayer_media_sync'] ) && $attachment['jwplayer_media_sync'] ) ? true : false;
 		if ( $sync ) {
-			jwplayer_media_init_sync( $media["ID"], $media["post_mime_type"], $media['post_title'], $media['content'] );
+			jwplayer_media_init_sync( $media['ID'], $media['post_mime_type'], $media['post_title'], $media['content'] );
 		}
 	}
 	return $media;
@@ -82,7 +82,7 @@ function jwplayer_media_edit_attachment( $post_id ) {
 }
 
 
-function jwplayer_media_hash( $media_id, $create_if_none=true ) {
+function jwplayer_media_hash( $media_id, $create_if_none = true ) {
 	$hash = get_post_meta( $media_id, 'jwplayer_media_hash', true );
 	if ( ! $hash && $create_if_none ) {
 		$post = get_post( $media_id );
@@ -95,8 +95,8 @@ function jwplayer_media_hash( $media_id, $create_if_none=true ) {
 }
 
 
-function jwplayer_media_init_sync( $media_id, $mime_type, $title, $description) {
-	$sourceformat = ( $mime_type ) ? preg_split( '/\//', $mime_type )[ 1 ] : 'mp4';
+function jwplayer_media_init_sync( $media_id, $mime_type, $title, $description ) {
+	$sourceformat = ( $mime_type ) ? preg_split( '/\//', $mime_type )[1] : 'mp4';
 	$params = array(
 		'sourcetype' => 'url',
 		'sourceurl' => wp_get_attachment_url( $media_id ),
@@ -228,7 +228,7 @@ function jwplayer_media_widget_body() {
 	<?php
 }
 
-function jwplayer_media_legacy_external_source( $url, $title=null ) {
+function jwplayer_media_legacy_external_source( $url, $title = null ) {
 	$external_media = get_option( 'jwplayer_legacy_external_media' );
 	if ( $external_media ) {
 		$external_media = unserialize( $external_media );
@@ -247,7 +247,7 @@ function jwplayer_media_legacy_external_source( $url, $title=null ) {
 	}
 }
 
-function jwplayer_media_add_external_source( $url, $title=null ) {
+function jwplayer_media_add_external_source( $url, $title = null ) {
 	$extension = pathinfo( $url, PATHINFO_EXTENSION );
 	$sourceformat = 'mp4';
 	foreach ( unserialize( JWPLAYER_SOURCE_FORMAT_EXTENSIONS ) as $format => $extensions ) {

--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -231,9 +231,9 @@ function jwplayer_media_widget_body() {
 function jwplayer_media_legacy_external_source( $url, $title = null ) {
 	$external_media = get_option( 'jwplayer_legacy_external_media' );
 	if ( $external_media ) {
-		$external_media = unserialize( $external_media );
+		$external_media = json_decode( $external_media );
 	} else {
-		add_option( 'jwplayer_legacy_external_media', serialize( array() ) );
+		add_option( 'jwplayer_legacy_external_media', wp_json_encode( array() ) );
 		$external_media = array();
 	}
 	$file_hash = md5( $url );
@@ -242,7 +242,7 @@ function jwplayer_media_legacy_external_source( $url, $title = null ) {
 	} else {
 		$hash = jwplayer_media_add_external_source( $url, $title );
 		$external_media[ $file_hash ] = $hash;
-		update_option( 'jwplayer_legacy_external_media', serialize( $external_media ) );
+		update_option( 'jwplayer_legacy_external_media', wp_json_encode( $external_media ) );
 		return $hash;
 	}
 }

--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -12,7 +12,7 @@ function jwplayer_media_init() {
 	add_action( 'admin_menu', 'jwplayer_media_add_video_box' );
 }
 
-function jwplayer_media_attachment_fields_to_edit( $form_fields, $media) {
+function jwplayer_media_attachment_fields_to_edit( $form_fields, $media ) {
 	if ( in_array( $media->post_mime_type, unserialize( JWPLAYER_MEDIA_MIME_TYPES ) ) ) {
 		$form_fields["jwplayer_media_sync"] = array(
 			"label" => "JW Player",
@@ -148,7 +148,7 @@ function jwplayer_media_sync( $hash, $media_id, $mime_type, $title, $description
 
 // Add the JW Player tab to the menu of the "Add media" window
 function jwplayer_media_menu( $tabs ) {
-	if ( get_option ('jwplayer_api_key' ) ) {
+	if ( get_option( 'jwplayer_api_key' ) ) {
 		$newtab = array( 'jwplayer' => 'JW Player' );
 		return array_merge( $tabs, $newtab );
 	}
@@ -183,7 +183,7 @@ function jwplayer_media_handle() {
 
 // Add the video widget to the authoring page, if enabled in the settings
 function jwplayer_media_add_video_box() {
-	if ( get_option( 'jwplayer_show_widget' ) && get_option ('jwplayer_api_key' ) ) {
+	if ( get_option( 'jwplayer_show_widget' ) && get_option( 'jwplayer_api_key' ) ) {
 		add_meta_box( 'jwplayer-video-box', 'Insert media with JW Player', 'jwplayer_media_widget_body', 'post', 'side', 'high' );
 		add_meta_box( 'jwplayer-video-box', 'Insert media with JW Player', 'jwplayer_media_widget_body', 'page', 'side', 'high' );
 	}
@@ -229,7 +229,7 @@ function jwplayer_media_widget_body() {
 }
 
 function jwplayer_media_legacy_external_source( $url, $title=null ) {
-	$external_media = get_option ('jwplayer_legacy_external_media' );
+	$external_media = get_option( 'jwplayer_legacy_external_media' );
 	if ( $external_media ) {
 		$external_media = unserialize( $external_media );
 	} else {

--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -13,7 +13,7 @@ function jwplayer_media_init() {
 }
 
 function jwplayer_media_attachment_fields_to_edit( $form_fields, $media ) {
-	if ( in_array( $media->post_mime_type, unserialize( JWPLAYER_MEDIA_MIME_TYPES ), true ) ) {
+	if ( in_array( $media->post_mime_type, json_decode( JWPLAYER_MEDIA_MIME_TYPES ), true ) ) {
 		$form_fields['jwplayer_media_sync'] = array(
 			'label' => 'JW Player',
 			'input' => 'html',
@@ -53,7 +53,7 @@ function jwplayer_media_sync_form_html( $media ) {
 
 
 function jwplayer_media_attachment_fields_to_save( $media, $attachment ) {
-	if ( in_array( $media['post_mime_type'], unserialize( JWPLAYER_MEDIA_MIME_TYPES ), true ) ) {
+	if ( in_array( $media['post_mime_type'], json_decode( JWPLAYER_MEDIA_MIME_TYPES ), true ) ) {
 		$sync = ( isset( $attachment['jwplayer_media_sync'] ) && $attachment['jwplayer_media_sync'] ) ? true : false;
 		if ( $sync ) {
 			jwplayer_media_init_sync( $media['ID'], $media['post_mime_type'], $media['post_title'], $media['content'] );
@@ -250,7 +250,7 @@ function jwplayer_media_legacy_external_source( $url, $title = null ) {
 function jwplayer_media_add_external_source( $url, $title = null ) {
 	$extension = pathinfo( $url, PATHINFO_EXTENSION );
 	$sourceformat = 'mp4';
-	foreach ( unserialize( JWPLAYER_SOURCE_FORMAT_EXTENSIONS ) as $format => $extensions ) {
+	foreach ( json_decode( JWPLAYER_SOURCE_FORMAT_EXTENSIONS ) as $format => $extensions ) {
 		if ( in_array( $extension, $extensions, true ) ) {
 			$sourceformat = $format;
 			break;

--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -13,7 +13,7 @@ function jwplayer_media_init() {
 }
 
 function jwplayer_media_attachment_fields_to_edit( $form_fields, $media ) {
-	if ( in_array( $media->post_mime_type, unserialize( JWPLAYER_MEDIA_MIME_TYPES ) ) ) {
+	if ( in_array( $media->post_mime_type, unserialize( JWPLAYER_MEDIA_MIME_TYPES ), true ) ) {
 		$form_fields['jwplayer_media_sync'] = array(
 			'label' => 'JW Player',
 			'input' => 'html',
@@ -53,7 +53,7 @@ function jwplayer_media_sync_form_html( $media ) {
 
 
 function jwplayer_media_attachment_fields_to_save( $media, $attachment ) {
-	if ( in_array( $media['post_mime_type'], unserialize( JWPLAYER_MEDIA_MIME_TYPES ) ) ) {
+	if ( in_array( $media['post_mime_type'], unserialize( JWPLAYER_MEDIA_MIME_TYPES ), true ) ) {
 		$sync = ( isset( $attachment['jwplayer_media_sync'] ) && $attachment['jwplayer_media_sync'] ) ? true : false;
 		if ( $sync ) {
 			jwplayer_media_init_sync( $media['ID'], $media['post_mime_type'], $media['post_title'], $media['content'] );
@@ -251,7 +251,7 @@ function jwplayer_media_add_external_source( $url, $title = null ) {
 	$extension = pathinfo( $url, PATHINFO_EXTENSION );
 	$sourceformat = 'mp4';
 	foreach ( unserialize( JWPLAYER_SOURCE_FORMAT_EXTENSIONS ) as $format => $extensions ) {
-		if ( in_array( $extension, $extensions ) ) {
+		if ( in_array( $extension, $extensions, true ) ) {
 			$sourceformat = $format;
 			break;
 		}

--- a/jw-player/include/proxy.php
+++ b/jw-player/include/proxy.php
@@ -22,10 +22,7 @@ function jwplayer_proxy() {
 	global $JWPLAYER_PROXY_METHODS;
 	$nonce = '';
 
-	if ( ! empty( $_GET['token'] ) ) {
-		$nonce = sanitize_text_field( wp_unslash( $_GET['token'] ) ); // input var okay
-	}
-	if ( ! wp_verify_nonce( $nonce, 'jwplayer-widget-nonce' ) ) {
+	if ( ! isset( $_GET['token'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['token'] ) ), 'jwplayer-widget-nonce' ) ) { // Input var okay
 		return;
 	}
 
@@ -34,9 +31,7 @@ function jwplayer_proxy() {
 		return;
 	}
 
-	if ( ! empty( $_GET['method'] ) ) {
-		$method = sanitize_text_field( wp_unslash( $_GET['method'] ) ); // input var okay
-	}
+	$method = ! empty( $_GET['method'] ) ? sanitize_text_field( wp_unslash( $_GET['method'] ) ) : null; // Input var okay
 
 	if ( null === $method ) {
 		jwplayer_json_error( 'Method was not specified' );
@@ -57,9 +52,9 @@ function jwplayer_proxy() {
 
 	$params = array();
 
-	foreach ( $_GET as $name => $value ) {
+	foreach ( $_GET as $name => $value ) { // Input var okay
 		if ( 'method' !== $name ) {
-			$params[ $name ] = sanitize_text_field( wp_unslash( $value ) ); // input var okay
+			$params[ $name ] = sanitize_text_field( wp_unslash( $value ) ); // Input var okay
 		}
 	}
 

--- a/jw-player/include/proxy.php
+++ b/jw-player/include/proxy.php
@@ -43,7 +43,7 @@ function jwplayer_proxy() {
 		return;
 	}
 
-	if ( ! in_array( $method, $JWPLAYER_PROXY_METHODS ) ) {
+	if ( ! in_array( $method, $JWPLAYER_PROXY_METHODS, true ) ) {
 		jwplayer_json_error( 'Access denied' );
 		return;
 	}
@@ -58,7 +58,7 @@ function jwplayer_proxy() {
 	$params = array();
 
 	foreach ( $_GET as $name => $value ) {
-		if ( 'method' != $name ) {
+		if ( 'method' !== $name ) {
 			$params[ $name ] = sanitize_text_field( wp_unslash( $value ) ); // input var okay
 		}
 	}

--- a/jw-player/include/proxy.php
+++ b/jw-player/include/proxy.php
@@ -23,7 +23,7 @@ function jwplayer_proxy() {
 	$nonce = '';
 
 	if ( ! empty( $_GET['token'] ) ) {
-		$nonce = sanitize_text_field( $_GET['token'] ); // input var okay
+		$nonce = sanitize_text_field( wp_unslash( $_GET['token'] ) ); // input var okay
 	}
 	if ( ! wp_verify_nonce( $nonce, 'jwplayer-widget-nonce' ) ) {
 		return;
@@ -35,7 +35,7 @@ function jwplayer_proxy() {
 	}
 
 	if ( ! empty( $_GET['method'] ) ) {
-		$method = sanitize_text_field( $_GET['method'] ); // input var okay
+		$method = sanitize_text_field( wp_unslash( $_GET['method'] ) ); // input var okay
 	}
 
 	if ( null === $method ) {
@@ -59,7 +59,7 @@ function jwplayer_proxy() {
 
 	foreach ( $_GET as $name => $value ) {
 		if ( 'method' != $name ) {
-			$params[ $name ] = sanitize_text_field( $value ); // input var okay
+			$params[ $name ] = sanitize_text_field( wp_unslash( $value ) ); // input var okay
 		}
 	}
 

--- a/jw-player/include/settings.php
+++ b/jw-player/include/settings.php
@@ -6,7 +6,7 @@ function jwplayer_settings_init() {
 	add_options_page ( 'JW Player Plugin Settings', 'JW Player', 'manage_options', 'jwplayer_settings', 'jwplayer_settings_page' );
 	add_settings_section( 'jwplayer_setting_section', null, '__return_true', 'jwplayer_settings' );
 
-	if ( get_option ( 'jwplayer_api_key' ) ) {
+	if ( get_option( 'jwplayer_api_key' ) ) {
 		add_settings_field( 'jwplayer_logout_link', 'Authorization', 'jwplayer_setting_logout_link', 'jwplayer_settings', 'jwplayer_setting_section' );
 		add_settings_field( 'jwplayer_player', 'Default player', 'jwplayer_setting_player', 'jwplayer_settings', 'jwplayer_setting_section' );
 		add_settings_field( 'jwplayer_show_widget', 'Authoring page widget', 'jwplayer_setting_show_widget', 'jwplayer_settings', 'jwplayer_setting_section' );
@@ -26,7 +26,7 @@ function jwplayer_settings_init() {
 		add_settings_field( 'jwplayer_login_link', 'Authorization', 'jwplayer_setting_login_link', 'jwplayer_settings', 'jwplayer_setting_section' );
 	}
 
-	if ( get_option ( 'jwplayer_api_key' ) && get_option ( 'jwplayer_custom_shortcode_parser' ) ) {
+	if ( get_option( 'jwplayer_api_key' ) && get_option( 'jwplayer_custom_shortcode_parser' ) ) {
 		add_settings_section( 'jwplayer_shortcode_section', 'Shortcode Settings', 'jwplayer_setting_section_shortcode', 'jwplayer_settings' );
 
 		add_settings_field( 'jwplayer_shortcode_category_filter', 'Category pages', 'jwplayer_setting_custom_shortcode_category', 'jwplayer_settings', 'jwplayer_shortcode_section' );
@@ -65,7 +65,7 @@ function jwplayer_settings_page() {
 // The logout link on the settings page
 function jwplayer_setting_logout_link() {
 	$logout_url = get_admin_url( null, 'admin.php?page=jwplayer_logout_page' );
-	$api_key = get_option ('jwplayer_api_key' );
+	$api_key = get_option( 'jwplayer_api_key' );
 	echo 'Authorized with api key <em>' . esc_html( $api_key ) . '</em>. <a href="' . esc_url( $logout_url ) . '">Deauthorize</a>.';
 }
 
@@ -102,7 +102,7 @@ function jwplayer_setting_content_mask() {
 
 // The setting for the default player
 function jwplayer_setting_player() {
-	$api_key = get_option ('jwplayer_api_key' );
+	$api_key = get_option( 'jwplayer_api_key' );
 	$loggedin = ! empty( $api_key );
 	if ( $loggedin ) {
 		$response = jwplayer_api_call( '/players/list' );

--- a/jw-player/include/settings.php
+++ b/jw-player/include/settings.php
@@ -13,7 +13,7 @@ function jwplayer_settings_init() {
 		add_settings_field( 'jwplayer_nr_videos', 'Videos in widget', 'jwplayer_setting_nr_videos', 'jwplayer_settings', 'jwplayer_setting_section' );
 		add_settings_field( 'jwplayer_timeout', 'Timeout for signed links', 'jwplayer_setting_timeout', 'jwplayer_settings', 'jwplayer_setting_section' );
 		add_settings_field( 'jwplayer_content_mask', 'Content DNS mask', 'jwplayer_setting_content_mask', 'jwplayer_settings', 'jwplayer_setting_section' );
-		add_settings_field( 'jwplayer_custom_shortcode_parser', 'Custom shortcode parser', 'jwplayer_setting_custom_shortcode', 'jwplayer_settings', 'jwplayer_setting_section');
+		add_settings_field( 'jwplayer_custom_shortcode_parser', 'Custom shortcode parser', 'jwplayer_setting_custom_shortcode', 'jwplayer_settings', 'jwplayer_setting_section' );
 
 		register_setting( 'jwplayer_settings', 'jwplayer_nr_videos', 'absint' );
 		register_setting( 'jwplayer_settings', 'jwplayer_timeout', 'absint' );
@@ -21,8 +21,7 @@ function jwplayer_settings_init() {
 		register_setting( 'jwplayer_settings', 'jwplayer_player', 'jwplayer_validate_player' );
 		register_setting( 'jwplayer_settings', 'jwplayer_show_widget', 'jwplayer_validate_boolean' );
 		register_setting( 'jwplayer_settings', 'jwplayer_custom_shortcode_parser', 'jwplayer_validate_boolean' );
-	}
-	else {
+	} else {
 		add_settings_field( 'jwplayer_login_link', 'Authorization', 'jwplayer_setting_login_link', 'jwplayer_settings', 'jwplayer_setting_section' );
 	}
 
@@ -41,10 +40,10 @@ function jwplayer_settings_init() {
 	}
 
 	// Legacy redirect
-	$botr_active = is_plugin_active('bits-on-the-run/bitsontherun.php');
+	$botr_active = is_plugin_active( 'bits-on-the-run/bitsontherun.php' );
 	if ( $botr_active || get_option( 'jwplayer_import_done' ) ) {
 		add_settings_section( 'jwplayer_setting_media_section', 'JW Player Plugin', '__return_true', 'media' );
-		add_settings_field( 'jwplayer_setting_media', 'JW Player Plugin Settings', 'jwplayer_setting_media_redirect', 'media', 'jwplayer_setting_media_section');
+		add_settings_field( 'jwplayer_setting_media', 'JW Player Plugin Settings', 'jwplayer_setting_media_redirect', 'media', 'jwplayer_setting_media_section' );
 	}
 }
 
@@ -159,7 +158,7 @@ function jwplayer_setting_custom_shortcode() {
 	echo ' value="true" /> ';
 	echo '<label for="jwplayer_custom_shortcode_parser">Use a custom shortcode parser to support shortcode replacement in different page types.</label>';
 	// TODO: Update URL to point to new docs.
-	echo '<p class="description"><a href="' . esc_url('https://support.jwplayer.com/customer/portal/articles/1403714-jw6-wordpress-plugin-reference')  . '">Learn more.</a></p>';
+	echo '<p class="description"><a href="' . esc_url( 'https://support.jwplayer.com/customer/portal/articles/1403714-jw6-wordpress-plugin-reference')  . '">Learn more.</a></p>';
 }
 
 // The login link on the settings page

--- a/jw-player/include/settings.php
+++ b/jw-player/include/settings.php
@@ -156,7 +156,7 @@ function jwplayer_setting_custom_shortcode() {
 	echo ' value="true" /> ';
 	echo '<label for="jwplayer_custom_shortcode_parser">Use a custom shortcode parser to support shortcode replacement in different page types.</label>';
 	// TODO: Update URL to point to new docs.
-	echo '<p class="description"><a href="' . esc_url( 'https://support.jwplayer.com/customer/portal/articles/1403714-jw6-wordpress-plugin-reference')  . '">Learn more.</a></p>';
+	echo '<p class="description"><a href="' . esc_url( 'https://support.jwplayer.com/customer/portal/articles/1403714-jw6-wordpress-plugin-reference' )  . '">Learn more.</a></p>';
 }
 
 // The login link on the settings page

--- a/jw-player/include/settings.php
+++ b/jw-player/include/settings.php
@@ -178,7 +178,7 @@ function jwplayer_setting_custom_shortcode_filter( $page_type ) {
 	$option_name = 'jwplayer_shortcode_' . $page_type . '_filter';
 	$current_value = get_option( $option_name );
 	$current_value = ( $current_value ) ? $current_value : 'content';
-	echo "<fieldset>";
+	echo '<fieldset>';
 	foreach ( unserialize( JWPLAYER_CUSTOM_SHORTCODE_OPTIONS ) as $option ) {
 			$option_label = ( 'strip' === $option ) ? 'Strip shortcode' : "Use $option";
 			echo '<label title="' . esc_attr( $option ) . '">';

--- a/jw-player/include/settings.php
+++ b/jw-player/include/settings.php
@@ -113,8 +113,7 @@ function jwplayer_setting_player() {
 			$key = $p['key'];
 			if ( $p['responsive'] ) {
 				$description = htmlentities( $p['name'] ) . ' (Responsive, ' . $p['aspectratio'] . ')';
-			}
-			else {
+			} else {
 				$description = htmlentities( $p['name'] ) . ' (Fixed size, ' . $p['width'] . 'x' . $p['height'] . ')';
 			}
 			echo '<option value="' . esc_attr( $key ) . '"' . esc_attr( selected( $key === $player, true, false ) ) . '>' . esc_html( $description ) . '</option>';
@@ -133,8 +132,7 @@ function jwplayer_setting_player() {
 				For example: <code>[jwplayer MdkflPz7-35rdi1pO]</code>
 			</p>
 		';
-	}
-	else {
+	} else {
 		echo '<input type="hidden" name="jwplayer_player" value="' . esc_attr( JWPLAYER_PLAYER ) . '" />';
 		echo 'You have to save log in before you can set this option.';
 	}

--- a/jw-player/include/settings.php
+++ b/jw-player/include/settings.php
@@ -3,7 +3,7 @@
 
 // Add the JW Player settings to the media page in the admin panel
 function jwplayer_settings_init() {
-	add_options_page ( 'JW Player Plugin Settings', 'JW Player', 'manage_options', 'jwplayer_settings', 'jwplayer_settings_page' );
+	add_options_page( 'JW Player Plugin Settings', 'JW Player', 'manage_options', 'jwplayer_settings', 'jwplayer_settings_page' );
 	add_settings_section( 'jwplayer_setting_section', null, '__return_true', 'jwplayer_settings' );
 
 	if ( get_option( 'jwplayer_api_key' ) ) {

--- a/jw-player/include/settings.php
+++ b/jw-player/include/settings.php
@@ -179,7 +179,7 @@ function jwplayer_setting_custom_shortcode_filter( $page_type ) {
 	$current_value = get_option( $option_name );
 	$current_value = ( $current_value ) ? $current_value : 'content';
 	echo '<fieldset>';
-	foreach ( unserialize( JWPLAYER_CUSTOM_SHORTCODE_OPTIONS ) as $option ) {
+	foreach ( json_decode( JWPLAYER_CUSTOM_SHORTCODE_OPTIONS ) as $option ) {
 			$option_label = ( 'strip' === $option ) ? 'Strip shortcode' : "Use $option";
 			echo '<label title="' . esc_attr( $option ) . '">';
 			echo '<input type="radio" value="' . esc_attr( $option ) . '" name="' . esc_attr( $option_name ) . '" '. checked( $current_value, $option ) . '/>';

--- a/jw-player/include/settings.php
+++ b/jw-player/include/settings.php
@@ -168,7 +168,7 @@ function jwplayer_setting_login_link() {
 function jwplayer_setting_section_shortcode() {
 	echo '<p>';
 	echo '    You can configure wether you want JW Player to embed in overview pages (home, tags, etc). Depending';
-	echo '    upon your Wordpress theme, the JW Player plugin must render the shortcodes from either ';
+	echo '    upon your WordPress theme, the JW Player plugin must render the shortcodes from either ';
 	echo '    <code>the_excerpt</code> or <code>the_content</code>. The third option is to disable player embeds';
 	echo '    on a specific page type. This will strip out the shortcode.';
 	echo '</p>';

--- a/jw-player/include/settings.php
+++ b/jw-player/include/settings.php
@@ -208,5 +208,5 @@ function jwplayer_setting_custom_shortcode_home() {
 
 function jwplayer_setting_media_redirect() {
 	$redirect_url = get_admin_url( null, 'options-general.php?page=jwplayer_settings' );
-	echo "JW Player plugin settings have moved. Please <a href='$redirect_url' title='Manage JW Player Plugin'>go here</a> now.";
+	echo 'JW Player plugin settings have moved. Please <a href="' . esc_url( $redirect_url ) . '" title="Manage JW Player Plugin">go here</a> now.';
 }

--- a/jw-player/include/settings.php
+++ b/jw-player/include/settings.php
@@ -180,14 +180,13 @@ function jwplayer_setting_custom_shortcode_filter( $page_type ) {
 	$current_value = ( $current_value ) ? $current_value : 'content';
 	echo "<fieldset>";
 	foreach ( unserialize( JWPLAYER_CUSTOM_SHORTCODE_OPTIONS ) as $option ) {
-			$checked = ( $current_value === $option ) ? 'checked="checked"' : '';
 			$option_label = ( 'strip' === $option ) ? 'Strip shortcode' : "Use $option";
-			echo "<label title='$option'>";
-			echo "<input type='radio' value='$option' name='$option_name' $checked />";
-			echo "<span>&nbsp;$option_label</span>";
+			echo '<label title="' . esc_attr( $option ) . '">';
+			echo '<input type="radio" value="' . esc_attr( $option ) . '" name="' . esc_attr( $option_name ) . '" '. checked( $current_value, $option ) . '/>';
+			echo '<span>&nbsp;' . esc_html( $option_label ) . '</span>';
 			echo '</label>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
 	}
-	echo "</fieldset>";
+	echo '</fieldset>';
 }
 
 function jwplayer_setting_custom_shortcode_category( $page_type = 'category' ) {

--- a/jw-player/include/shortcode.php
+++ b/jw-player/include/shortcode.php
@@ -4,7 +4,7 @@ $jwplayer_shortcode_embedded_players = array();
 
 function jwplayer_shortcode_init() {
 	// Activate the JW Player shortcode.
-	if ( get_option ( 'jwplayer_custom_shortcode_parser' ) ) {
+	if ( get_option( 'jwplayer_custom_shortcode_parser' ) ) {
 		add_filter( 'the_content', 'jwplayer_shortcode_content_filter', 11 );
 		add_filter( 'the_excerpt', 'jwplayer_shortcode_excerpt_filter', 11 );
 		add_filter( 'widget_text', 'jwplayer_shortcode_text_filter',  11 );
@@ -18,7 +18,7 @@ function jwplayer_shortcode_init() {
 function jwplayer_shortcode_handle( $atts ) {
 	jwplayer_log( $atts, true );
 	// Check for a api key
-	$api_key = get_option ( 'jwplayer_api_key' );
+	$api_key = get_option( 'jwplayer_api_key' );
 	if ( empty( $api_key ) ) {
 		return '';
 	}
@@ -78,11 +78,11 @@ function jwplayer_shortcode_parser( $matches ) {
 	$atts = array();
 	if ( preg_match_all( $param_regex, $text, $match, PREG_SET_ORDER ) ) {
 		foreach ( $match as $p_match ) {
-			if ( !empty( $p_match[1] ) ) {
+			if ( ! empty( $p_match[1] ) ) {
 				$atts[ $p_match[1] ] = stripcslashes( $p_match[2] );
-			} elseif ( !empty( $p_match[3] ) ) {
+			} elseif ( ! empty( $p_match[3] ) ) {
 				$atts[ $p_match[3] ] = stripcslashes( $p_match[4] );
-			} elseif ( !empty( $p_match[5] ) ) {
+			} elseif ( ! empty( $p_match[5] ) ) {
 				$atts[ $p_match[5] ] = stripcslashes( $p_match[6] );
 			} elseif ( isset( $p_match[7] ) && strlen( $p_match[7] ) ) {
 				$atts[] = stripcslashes( $p_match[7] );

--- a/jw-player/include/shortcode.php
+++ b/jw-player/include/shortcode.php
@@ -140,7 +140,7 @@ function jwplayer_shortcode_handle_legacy( $atts ) {
 	if ( isset( $hash ) ) {
 		return jwplayer_shortcode_create_js_embed( $hash, $player_hash, $atts );
 	}
-	return "<!-- ERROR PARSING SHORTCODE -->";
+	return '<!-- ERROR PARSING SHORTCODE -->';
 }
 
 function jwplayer_shortcode_filter_player_params( $atts ) {

--- a/jw-player/include/shortcode.php
+++ b/jw-player/include/shortcode.php
@@ -232,7 +232,7 @@ function jwplayer_shortcode_create_js_embed( $media_hash, $player_hash = null, $
 	if ( JWPLAYER_DISABLE_FITVIDS ) {
 		if ( $player_script ) {
 			return "
-		<script type='text/javascript' src='" . esc_url( "$protocol://$content_mask/libraries/$player_hash.js" ) . "></script>
+		<script type='text/javascript' src='" . esc_url( "$protocol://$content_mask/libraries/$player_hash.js" ) . "'></script>
 			<div id='" . esc_js( $element_id ) . "'></div>
 		<script type='text/javascript'>
 			" . 'if(typeof(jQuery)=="function"){(function($){$.fn.fitVids=function(){}})(jQuery)};' . "

--- a/jw-player/include/shortcode.php
+++ b/jw-player/include/shortcode.php
@@ -47,22 +47,22 @@ function jwplayer_shortcode_filter( $filter_type = "content", $content = "" ) {
 	$option_name = false;
 	if ( is_archive() ) {
 		$option_name = 'jwplayer_shortcode_category_filter';
-	} else if ( is_search() ) {
+	} elseif ( is_search() ) {
 		$option_name = 'jwplayer_shortcode_search_filter';
-	} else if ( is_tag() ) {
+	} elseif ( is_tag() ) {
 		$option_name = 'jwplayer_shortcode_tag_filter';
-	} else if ( is_home() ) {
+	} elseif ( is_home() ) {
 		$option_name = 'jwplayer_shortcode_home_filter';
 	}
 	if ( $option_name ) {
 		$action = get_option( $option_name );
-	} else if ( "content" === $filter_type ) {
+	} elseif ( "content" === $filter_type ) {
 		$action = $filter_type;
 	}
 	$tag_regex = '/(.?)\[(jwplayer|jwplatform)\b(.*?)(?:(\/))?\](?:(.+?)\[\/\2\])?(.?)/s';
 	if ( $action === $filter_type ) {
 		$content = preg_replace_callback( $tag_regex, jwplayer_shortcode_parser, $content );
-	} else if ( 'strip' === $action ) {
+	} elseif ( 'strip' === $action ) {
 		$content = preg_replace_callback( $tag_regex, jwplayer_shortcode_stripper, $content );
 	}
 	return $content;
@@ -117,11 +117,11 @@ function jwplayer_shortcode_handle_legacy( $atts ) {
 		}
 		unset( $atts['mediaid'] );
 		// };
-	} else if ( isset ( $atts['file'] ) ) {
+	} elseif ( isset ( $atts['file'] ) ) {
 		$title = ( isset ( $atts['title'] ) ) ? $atts['title'] : null;
 		$hash = jwplayer_media_legacy_external_source( $atts['file'], $title );
 		unset( $atts['file'] );
-	} else if ( isset ( $atts['playlistid'] ) ) {
+	} elseif ( isset ( $atts['playlistid'] ) ) {
 		$imported_playlists = get_option( 'jwplayer_imported_playlists' );
 		if ( $imported_playlists && array_key_exists( $atts['playlistid'], $imported_playlists ) ) {
 			$hash = $imported_playlists[ $atts['playlistid'] ];
@@ -161,7 +161,7 @@ function jwplayer_shortcode_filter_player_params( $atts ) {
 		}
 		$value = ( array_key_exists( strval( $value ), $translate ) ) ? $translate[$value] : $value;
 		if ( strpos($param, '__') ) {
-			$parts = explode('__', $param);
+			$parts = explode( '__', $param);
 			$last_part = end($parts);
 			$a = &$params;
 			foreach ( $parts as $part ) {
@@ -211,13 +211,13 @@ function jwplayer_shortcode_create_js_embed( $media_hash, $player_hash = null, $
 	$params = jwplayer_shortcode_filter_player_params($params);
 	if ( count( $params ) ) {
 		// Support for player tracks.
-		foreach (array('sources', 'tracks') as $option) {
+		foreach (array( 'sources', 'tracks') as $option) {
 			if ( isset($params[$option]) ) {
 				$json = '[' . $params[$option] . ']';
-				$obj = json_decode(preg_replace('/[{, ]{1}(\w+):/i', '"\1":', $json));
+				$obj = json_decode(preg_replace( '/[{, ]{1}(\w+):/i', '"\1":', $json));
 				if ( null === $obj ) {
-					$json = str_replace(array('"',  "'"), array('\"', '"'), $json);
-					$obj = json_decode(preg_replace('/[{, ]{1}(\w+):/i', '"\1":', $json));
+					$json = str_replace(array( '"',  "'"), array( '\"', '"'), $json);
+					$obj = json_decode(preg_replace( '/[{, ]{1}(\w+):/i', '"\1":', $json));
 				}
 				$params[$option] = $obj;
 			}

--- a/jw-player/include/shortcode.php
+++ b/jw-player/include/shortcode.php
@@ -227,22 +227,60 @@ function jwplayer_shortcode_create_js_embed( $media_hash, $player_hash = null, $
 	if ( ! isset( $params['source'] ) ) {
 		$params['playlist'] = $xml;
 	}
-	$paramstring = json_encode( $params );
-	foreach (  array( '&amp;' => '&', '&#038;' => '&', '\/' => '/' ) as $from => $to ) {
-		$paramstring = str_replace( $from, $to, $paramstring );
-	}
+	
+//	$paramstring = json_encode( $params );
+//	foreach (  array( '&amp;' => '&', '&#038;' => '&', '\/' => '/' ) as $from => $to ) {
+//		$paramstring = str_replace( $from, $to, $paramstring );
+//	}
 
 	// Redeclare fitVids to stop it from breaking the JW Player embedding.
-	$fitbits = ( JWPLAYER_DISABLE_FITVIDS ) ? 'if(typeof(jQuery)=="function"){(function($){$.fn.fitVids=function(){}})(jQuery)};' : '';
+	//$fitbits = ( JWPLAYER_DISABLE_FITVIDS ) ? 'if(typeof(jQuery)=="function"){(function($){$.fn.fitVids=function(){}})(jQuery)};' : '';
 
-	return "
+	if ( JWPLAYER_DISABLE_FITVIDS ) {
+		if ( $player_script ) {
+			return "
 		$player_script
-		<div id='$element_id'></div>
+			<div id='" . esc_js( $element_id ) . "'></div>
 		<script type='text/javascript'>
-			$fitbits
-			jwplayer('$element_id').setup(
-				$paramstring
+			" . 'if(typeof(jQuery)=="function"){(function($){$.fn.fitVids=function(){}})(jQuery)};' . "
+				jwplayer('" . esc_js( $element_id ) . "').setup(
+				" . wp_json_encode( $params ) . "
 			);
 		</script>
 	";
+		} else { // no player script
+			return "
+			<div id='" . esc_js( $element_id ) . "'></div>
+		<script type='text/javascript'>
+			" . 'if(typeof(jQuery)=="function"){(function($){$.fn.fitVids=function(){}})(jQuery)};' . "
+				jwplayer('" . esc_js( $element_id ) . "').setup(
+				" . wp_json_encode( $params ) . "
+			);
+		</script>
+	";
+		}
+	} else {
+
+		// no fitvids script here.
+		if ( $player_script ) {
+			return "
+		$player_script
+			<div id='" . esc_js( $element_id ) . "'></div>
+		<script type='text/javascript'>
+				jwplayer('" . esc_js( $element_id ) . "').setup(
+				" . wp_json_encode( $params ) . "
+			);
+		</script>
+	";
+		} else { // no player script
+			return "
+			<div id='" . esc_js( $element_id ) . "'></div>
+		<script type='text/javascript'>
+				jwplayer('" . esc_js( $element_id ) . "').setup(
+				" . wp_json_encode( $params ) . "
+			);
+		</script>
+	";
+		}
+	}
 }

--- a/jw-player/include/shortcode.php
+++ b/jw-player/include/shortcode.php
@@ -74,7 +74,7 @@ function jwplayer_shortcode_parser( $matches ) {
 	}
 	$param_regex = '/([\w.]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w.]+)\s*=\s*\'([^\']*)\'(?:\s|$)|([\w.]+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/';
 	$text = preg_replace( "/[\x{00a0}\x{200b}]+/u", ' ', $matches[3] );
-	$text = preg_replace( "/&#8221;|&#8243;/", "\"", preg_replace( "/&#8217;|&#8242;/", "'", $text ) );
+	$text = preg_replace( '/&#8221;|&#8243;/', '"', preg_replace( '/&#8217;|&#8242;/', "'", $text ) );
 	$atts = array();
 	if ( preg_match_all( $param_regex, $text, $match, PREG_SET_ORDER ) ) {
 		foreach ( $match as $p_match ) {

--- a/jw-player/include/shortcode.php
+++ b/jw-player/include/shortcode.php
@@ -73,7 +73,7 @@ function jwplayer_shortcode_parser( $matches ) {
 		return substr( $matches[0], 1, -1 );
 	}
 	$param_regex = '/([\w.]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w.]+)\s*=\s*\'([^\']*)\'(?:\s|$)|([\w.]+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/';
-	$text = preg_replace( "/[\x{00a0}\x{200b}]+/u", " ", $matches[3] );
+	$text = preg_replace( "/[\x{00a0}\x{200b}]+/u", ' ', $matches[3] );
 	$text = preg_replace( "/&#8221;|&#8243;/", "\"", preg_replace( "/&#8217;|&#8242;/", "'", $text ) );
 	$atts = array();
 	if ( preg_match_all( $param_regex, $text, $match, PREG_SET_ORDER ) ) {
@@ -157,7 +157,7 @@ function jwplayer_shortcode_filter_player_params( $atts ) {
 		if ( is_numeric( $param ) ) {
 			continue;
 		}
-		if ( in_array( $param, $strip ) ) {
+		if ( in_array( $param, $strip, true ) ) {
 			continue;
 		}
 		$value = ( array_key_exists( strval( $value ), $translate ) ) ? $translate[ $value ] : $value;
@@ -189,7 +189,7 @@ function jwplayer_shortcode_create_js_embed( $media_hash, $player_hash = null, $
 	$content_mask = jwplayer_get_content_mask();
 	$protocol = ( is_ssl() && BOTR_CONTENT_MASK === $content_mask ) ? 'https' : 'http';
 
-	if ( in_array( $player_hash, $jwplayer_shortcode_embedded_players ) ) {
+	if ( in_array( $player_hash, $jwplayer_shortcode_embedded_players, true ) ) {
 		$player_script = '';
 	} else {
 		// Injecting script tag because there's no way to properly enqueue a javascript

--- a/jw-player/include/shortcode.php
+++ b/jw-player/include/shortcode.php
@@ -25,13 +25,13 @@ function jwplayer_shortcode_handle( $atts ) {
 	$keys = array_keys( $atts );
 	$r = '/(?P<media>[0-9a-z]{8})(?:[-_])?(?P<player>[0-9a-z]{8})?/i';
 	$m = array();
-	if (  count( $keys ) > 0 && 0 === $keys[0] && preg_match( $r, $atts[0], $m) ) {
+	if ( count( $keys ) > 0 && 0 === $keys[0] && preg_match( $r, $atts[0], $m ) ) {
 		unset( $atts[0] );
 		$player = ( isset( $m['player'] ) ) ? $m['player'] : null;
 		return jwplayer_shortcode_create_js_embed( $m['media'], $player, $atts );
 	} else {
 		// Legacy shortcode
-		return jwplayer_shortcode_handle_legacy($atts);
+		return jwplayer_shortcode_handle_legacy( $atts );
 	}
 }
 
@@ -187,7 +187,7 @@ function jwplayer_shortcode_create_js_embed( $media_hash, $player_hash = null, $
 	global $jwplayer_shortcode_embedded_players;
 	$player_hash = ( null === $player_hash ) ? get_option( 'jwplayer_player' ) : $player_hash;
 	$content_mask = jwplayer_get_content_mask();
-	$protocol = ( is_ssl() && $content_mask === BOTR_CONTENT_MASK ) ? 'https' : 'http';
+	$protocol = ( is_ssl() && BOTR_CONTENT_MASK === $content_mask ) ? 'https' : 'http';
 
 	if ( in_array( $player_hash, $jwplayer_shortcode_embedded_players ) ) {
 		$player_script = '';
@@ -229,7 +229,7 @@ function jwplayer_shortcode_create_js_embed( $media_hash, $player_hash = null, $
 	}
 	$paramstring = json_encode( $params );
 	foreach (  array( '&amp;' => '&', '&#038;' => '&', '\/' => '/' ) as $from => $to ) {
-		$paramstring = str_replace($from, $to, $paramstring);
+		$paramstring = str_replace( $from, $to, $paramstring );
 	}
 
 	// Redeclare fitVids to stop it from breaking the JW Player embedding.

--- a/jw-player/include/shortcode.php
+++ b/jw-player/include/shortcode.php
@@ -35,15 +35,15 @@ function jwplayer_shortcode_handle( $atts ) {
 	}
 }
 
-function jwplayer_shortcode_content_filter( $content = "" ) {
+function jwplayer_shortcode_content_filter( $content = '' ) {
 	return jwplayer_shortcode_filter( 'content', $content );
 }
 
-function jwplayer_shortcode_excerpt_filter( $content = "" ) {
+function jwplayer_shortcode_excerpt_filter( $content = '' ) {
 	return jwplayer_shortcode_filter( 'excerpt', $content );
 }
 
-function jwplayer_shortcode_filter( $filter_type = "content", $content = "" ) {
+function jwplayer_shortcode_filter( $filter_type = 'content', $content = '' ) {
 	$option_name = false;
 	if ( is_archive() ) {
 		$option_name = 'jwplayer_shortcode_category_filter';
@@ -56,7 +56,7 @@ function jwplayer_shortcode_filter( $filter_type = "content", $content = "" ) {
 	}
 	if ( $option_name ) {
 		$action = get_option( $option_name );
-	} elseif ( "content" === $filter_type ) {
+	} elseif ( 'content' === $filter_type ) {
 		$action = $filter_type;
 	}
 	$tag_regex = '/(.?)\[(jwplayer|jwplatform)\b(.*?)(?:(\/))?\](?:(.+?)\[\/\2\])?(.?)/s';
@@ -69,7 +69,7 @@ function jwplayer_shortcode_filter( $filter_type = "content", $content = "" ) {
 }
 
 function jwplayer_shortcode_parser( $matches ) {
-	if ( "[" === $matches[1] && "]" === $matches[6] ) {
+	if ( '[' === $matches[1] && ']' === $matches[6] ) {
 		return substr( $matches[0], 1, -1 );
 	}
 	$param_regex = '/([\w.]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w.]+)\s*=\s*\'([^\']*)\'(?:\s|$)|([\w.]+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/';
@@ -97,7 +97,7 @@ function jwplayer_shortcode_parser( $matches ) {
 }
 
 function jwplayer_shortcode_stripper( $matches ) {
-	if ( "[" === $matches[1] && "]" === $matches[6] ) {
+	if ( '[' === $matches[1] && ']' === $matches[6] ) {
 		return substr( $matches[0], 1, -1 );
 	}
 	return $matches[1] . $matches[6];
@@ -117,11 +117,11 @@ function jwplayer_shortcode_handle_legacy( $atts ) {
 		}
 		unset( $atts['mediaid'] );
 		// };
-	} elseif ( isset ( $atts['file'] ) ) {
-		$title = ( isset ( $atts['title'] ) ) ? $atts['title'] : null;
+	} elseif ( isset( $atts['file'] ) ) {
+		$title = ( isset( $atts['title'] ) ) ? $atts['title'] : null;
 		$hash = jwplayer_media_legacy_external_source( $atts['file'], $title );
 		unset( $atts['file'] );
-	} elseif ( isset ( $atts['playlistid'] ) ) {
+	} elseif ( isset( $atts['playlistid'] ) ) {
 		$imported_playlists = get_option( 'jwplayer_imported_playlists' );
 		if ( $imported_playlists && array_key_exists( $atts['playlistid'], $imported_playlists ) ) {
 			$hash = $imported_playlists[ $atts['playlistid'] ];
@@ -130,7 +130,7 @@ function jwplayer_shortcode_handle_legacy( $atts ) {
 	}
 	// Try to get player
 	$player_hash = null;
-	if ( isset ( $atts['player'] ) ) {
+	if ( isset( $atts['player'] ) ) {
 		$imported_players = get_option( 'jwplayer_imported_players' );
 		if ( $imported_players && array_key_exists( $atts['player'], $imported_players ) ) {
 			$player_hash = $imported_players[ $atts['player'] ];
@@ -150,32 +150,33 @@ function jwplayer_shortcode_filter_player_params( $atts ) {
 		'true'  => true,
 		'false' => false,
 		'NULL'  => null,
-		'null'  => null
+		'null'  => null,
 	);
-	foreach ($atts as $param => $value) {
+
+	foreach ( $atts as $param => $value ) {
 		if ( is_numeric( $param ) ) {
 			continue;
 		}
 		if ( in_array( $param, $strip ) ) {
 			continue;
 		}
-		$value = ( array_key_exists( strval( $value ), $translate ) ) ? $translate[$value] : $value;
-		if ( strpos($param, '__') ) {
-			$parts = explode( '__', $param);
-			$last_part = end($parts);
+		$value = ( array_key_exists( strval( $value ), $translate ) ) ? $translate[ $value ] : $value;
+		if ( strpos( $param, '__' ) ) {
+			$parts = explode( '__', $param );
+			$last_part = end( $parts );
 			$a = &$params;
 			foreach ( $parts as $part ) {
 				if ( $part === $last_part ) {
-					$a[$part] = $value;
+					$a[ $part ] = $value;
 				} else {
 					if ( ! array_key_exists( $part, $a ) ) {
-						$a[$part] = array();
+						$a[ $part ] = array();
 					}
-					$a = &$a[$part];
+					$a = &$a[ $part ];
 				}
 			}
 		} else {
-			$params[$param] = $value;
+			$params[ $param ] = $value;
 		}
 	}
 	return $params;
@@ -208,25 +209,25 @@ function jwplayer_shortcode_create_js_embed( $media_hash, $player_hash = null, $
 		$xml = "$xml?exp=$expires&sig=$signature";
 	}
 
-	$params = jwplayer_shortcode_filter_player_params($params);
+	$params = jwplayer_shortcode_filter_player_params( $params );
 	if ( count( $params ) ) {
 		// Support for player tracks.
-		foreach (array( 'sources', 'tracks') as $option) {
-			if ( isset($params[$option]) ) {
-				$json = '[' . $params[$option] . ']';
-				$obj = json_decode(preg_replace( '/[{, ]{1}(\w+):/i', '"\1":', $json));
+		foreach ( array( 'sources', 'tracks' ) as $option ) {
+			if ( isset( $params[ $option ] ) ) {
+				$json = '[' . $params[ $option ] . ']';
+				$obj = json_decode( preg_replace( '/[{, ]{1}(\w+):/i', '"\1":', $json ) );
 				if ( null === $obj ) {
-					$json = str_replace(array( '"',  "'"), array( '\"', '"'), $json);
-					$obj = json_decode(preg_replace( '/[{, ]{1}(\w+):/i', '"\1":', $json));
+					$json = str_replace( array( '"',  "'" ), array( '\"', '"' ), $json );
+					$obj = json_decode( preg_replace( '/[{, ]{1}(\w+):/i', '"\1":', $json ) );
 				}
-				$params[$option] = $obj;
+				$params[ $option ] = $obj;
 			}
 		}
 	}
-	if ( ! isset ( $params['source'] ) ) {
+	if ( ! isset( $params['source'] ) ) {
 		$params['playlist'] = $xml;
 	}
-	$paramstring = json_encode($params);
+	$paramstring = json_encode( $params );
 	foreach (  array( '&amp;' => '&', '&#038;' => '&', '\/' => '/' ) as $from => $to ) {
 		$paramstring = str_replace($from, $to, $paramstring);
 	}

--- a/jw-player/include/shortcode.php
+++ b/jw-player/include/shortcode.php
@@ -194,7 +194,7 @@ function jwplayer_shortcode_create_js_embed( $media_hash, $player_hash = null, $
 	} else {
 		// Injecting script tag because there's no way to properly enqueue a javascript
 		// at this point in the process :'-(
-		$player_script = "<script type='text/javascript' src='$protocol://$content_mask/libraries/$player_hash.js'></script>";
+		$player_script = true;
 		$jwplayer_shortcode_embedded_players[] = $player_hash;
 	}
 
@@ -227,19 +227,12 @@ function jwplayer_shortcode_create_js_embed( $media_hash, $player_hash = null, $
 	if ( ! isset( $params['source'] ) ) {
 		$params['playlist'] = $xml;
 	}
-	
-//	$paramstring = json_encode( $params );
-//	foreach (  array( '&amp;' => '&', '&#038;' => '&', '\/' => '/' ) as $from => $to ) {
-//		$paramstring = str_replace( $from, $to, $paramstring );
-//	}
 
 	// Redeclare fitVids to stop it from breaking the JW Player embedding.
-	//$fitbits = ( JWPLAYER_DISABLE_FITVIDS ) ? 'if(typeof(jQuery)=="function"){(function($){$.fn.fitVids=function(){}})(jQuery)};' : '';
-
 	if ( JWPLAYER_DISABLE_FITVIDS ) {
 		if ( $player_script ) {
 			return "
-		$player_script
+		<script type='text/javascript' src='" . esc_url( "$protocol://$content_mask/libraries/$player_hash.js" ) . "></script>
 			<div id='" . esc_js( $element_id ) . "'></div>
 		<script type='text/javascript'>
 			" . 'if(typeof(jQuery)=="function"){(function($){$.fn.fitVids=function(){}})(jQuery)};' . "
@@ -264,7 +257,7 @@ function jwplayer_shortcode_create_js_embed( $media_hash, $player_hash = null, $
 		// no fitvids script here.
 		if ( $player_script ) {
 			return "
-		$player_script
+		<script type='text/javascript' src='" . esc_url( "$protocol://$content_mask/libraries/$player_hash.js" ) . "></script>
 			<div id='" . esc_js( $element_id ) . "'></div>
 		<script type='text/javascript'>
 				jwplayer('" . esc_js( $element_id ) . "').setup(

--- a/jw-player/include/utils.php
+++ b/jw-player/include/utils.php
@@ -4,14 +4,14 @@ function jwplayer_log( $msg, $print_r = false ) {
 	if ( 'wpvip' === $jwplayer_which_env ) {
 		return;
 	}
-	if (WP_DEBUG) {
+	if ( WP_DEBUG ) {
 		$msg = ( $print_r ) ? print_r( $msg, true ): $msg;
 		$upload_dir = wp_upload_dir();
 		$log_file = $upload_dir['basedir'] . '/.jw-player.log';
 		if ( ! file_exists( $log_file ) ) {
 			touch( $log_file );
 		}
-		$prefix = "[" . date( 'H:i:s' ) . "] ";
+		$prefix = '[' . date( 'H:i:s' ) . '] ';
 		$msg = $prefix . str_replace( "\n", "\n" . $prefix, $msg ) . "\n";
 		file_put_contents( $log_file, $msg, $flags=FILE_APPEND );
 	}

--- a/jw-player/include/utils.php
+++ b/jw-player/include/utils.php
@@ -13,7 +13,7 @@ function jwplayer_log( $msg, $print_r = false ) {
 		}
 		$prefix = '[' . date( 'H:i:s' ) . '] ';
 		$msg = $prefix . str_replace( "\n", "\n" . $prefix, $msg ) . "\n";
-		file_put_contents( $log_file, $msg, $flags=FILE_APPEND );
+		file_put_contents( $log_file, $msg, $flags = FILE_APPEND );
 	}
 }
 

--- a/jw-player/include/validation.php
+++ b/jw-player/include/validation.php
@@ -33,7 +33,7 @@ function jwplayer_validate_boolean( $value ) {
 }
 
 function jwplayer_validate_custom_shortcode( $value ) {
-	if ( in_array( $value, unserialize( JWPLAYER_CUSTOM_SHORTCODE_OPTIONS ) ) ) {
+	if ( in_array( $value, unserialize( JWPLAYER_CUSTOM_SHORTCODE_OPTIONS ), true ) ) {
 		return $value;
 	}
 	return 'content';

--- a/jw-player/include/validation.php
+++ b/jw-player/include/validation.php
@@ -33,7 +33,7 @@ function jwplayer_validate_boolean( $value ) {
 }
 
 function jwplayer_validate_custom_shortcode( $value ) {
-	if ( in_array( $value, unserialize( JWPLAYER_CUSTOM_SHORTCODE_OPTIONS ), true ) ) {
+	if ( in_array( $value, json_decode( JWPLAYER_CUSTOM_SHORTCODE_OPTIONS ), true ) ) {
 		return $value;
 	}
 	return 'content';

--- a/jw-player/include/validation.php
+++ b/jw-player/include/validation.php
@@ -2,7 +2,7 @@
 
 // Validate the settings for the default player
 function jwplayer_validate_player( $player_key ) {
-	$api_key = get_option ('jwplayer_api_key' );
+	$api_key = get_option( 'jwplayer_api_key' );
 	$loggedin = ! empty( $api_key );
 	if ( $loggedin ) {
 		$response = jwplayer_api_call( '/players/list' );

--- a/jw-player/jw-player.php
+++ b/jw-player/jw-player.php
@@ -72,8 +72,7 @@ define( 'JWPLAYER_DISABLE_FITVIDS', true );
 $jwplayer_which_env = null;
 if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
 	$jwplayer_which_env = 'wpvip';
-}
-else {
+} else {
 	$jwplayer_which_env = 'wp';
 }
 

--- a/jw-player/jw-player.php
+++ b/jw-player/jw-player.php
@@ -91,11 +91,11 @@ function jwplayer_add_options() {
 	add_option( 'jwplayer_shortcode_home_filter', JWPLAYER_CUSTOM_SHORTCODE_FILTER );
 }
 
-if ( 'wpvip' == $jwplayer_which_env ) {
+if ( 'wpvip' === $jwplayer_which_env ) {
 	if ( ! get_option( 'jwplayer_player' ) ) {
-			jwplayer_add_options();
+		jwplayer_add_options();
 	}
-} elseif ( 'wp' == $jwplayer_which_env ) {
+} elseif ( 'wp' === $jwplayer_which_env ) {
 	register_activation_hook( __FILE__, 'jwplayer_add_options' );
 }
 
@@ -112,6 +112,6 @@ jwplayer_media_init();
 jwplayer_shortcode_init();
 
 // Check for old plugin settings.
-if ( 'wp' == $jwplayer_which_env ) {
+if ( 'wp' === $jwplayer_which_env ) {
 	add_action( 'admin_menu', 'jwplayer_import_check_and_init' );
 }

--- a/jw-player/jw-player.php
+++ b/jw-player/jw-player.php
@@ -95,7 +95,7 @@ if ( 'wpvip' == $jwplayer_which_env ) {
 	if ( ! get_option( 'jwplayer_player' ) ) {
 			jwplayer_add_options();
 	}
-} else if ( 'wp' == $jwplayer_which_env ) {
+} elseif ( 'wp' == $jwplayer_which_env ) {
 	register_activation_hook( __FILE__, 'jwplayer_add_options' );
 }
 

--- a/jw-player/jw-player.php
+++ b/jw-player/jw-player.php
@@ -29,12 +29,12 @@ define( 'JWPLAYER_DASHBOARD', 'https://dashboard.jwplayer.com/' );
 define( 'JWPLAYER_TIMEOUT', '0' );
 define( 'JWPLAYER_CONTENT_MASK', 'content.jwplatform.com' );
 define( 'JWPLAYER_NR_VIDEOS', '5' );
-define( 'JWPLAYER_CUSTOM_SHORTCODE_OPTIONS', serialize( array( 'content', 'excerpt', 'strip' ) ) );
+define( 'JWPLAYER_CUSTOM_SHORTCODE_OPTIONS', wp_json_encode( array( 'content', 'excerpt', 'strip' ) ) );
 define( 'JWPLAYER_SHOW_WIDGET', false );
 define( 'JWPLAYER_CUSTOM_SHORTCODE_PARSER', false );
 define( 'JWPLAYER_CUSTOM_SHORTCODE_FILTER', 'content' );
 
-$JWPLAYER_MEDIA_MIME_TYPES = array(
+$jwplayer_media_mime_types = array(
 	'video/mp4',
 	'video/flv',
 	'video/webm',
@@ -42,9 +42,10 @@ $JWPLAYER_MEDIA_MIME_TYPES = array(
 	'audio/mpeg',
 	'audio/ogg',
 );
-define( 'JWPLAYER_MEDIA_MIME_TYPES', serialize( $JWPLAYER_MEDIA_MIME_TYPES ) );
 
-$JWPLAYER_SOURCE_FORMAT_EXTENSIONS = array(
+define( 'JWPLAYER_MEDIA_MIME_TYPES', wp_json_encode( $jwplayer_media_mime_types ) );
+
+$jwplayer_source_format_extensions = array(
 	'aac' => array( 'aac', 'm4a', 'f4a' ),
 	'flv' => array( 'flv' ),
 	'm3u8' => array( 'm3u', 'm3u8' ),
@@ -55,7 +56,7 @@ $JWPLAYER_SOURCE_FORMAT_EXTENSIONS = array(
 	'vorbis' => array( 'ogg', 'oga' ),
 	'webm' => array( 'webm' ),
 );
-define( 'JWPLAYER_SOURCE_FORMAT_EXTENSIONS', serialize( $JWPLAYER_SOURCE_FORMAT_EXTENSIONS ) );
+define( 'JWPLAYER_SOURCE_FORMAT_EXTENSIONS', wp_json_encode( $jwplayer_source_format_extensions ) );
 
 /*
 FitVids.js is not compatible with the JW Player 6 because it breaks the way the player

--- a/jw-player/readme.txt
+++ b/jw-player/readme.txt
@@ -1,4 +1,4 @@
-=== JW Player for Wordpress ===
+=== JW Player for WordPress ===
 Contributors: LongTail Video
 Tags: jwplayer, jw, player, jwplatform, video, media, html5
 Requires at least: 4.3
@@ -6,13 +6,13 @@ Tested up to: 4.4.1
 Stable tag: 0.10.1 beta
 License: GPLv3
 
-Upload and embed videos with your JW Player account to seamlessly integrate video into your Wordpress website.
+Upload and embed videos with your JW Player account to seamlessly integrate video into your WordPress website.
 
 == Description ==
 
-**BE AWARE: The plugin is in beta. We've tested it locally, but because of the myriad of different Wordpress setups it could be possible that you run into issues. If you do run into an issue we encourage you to [report this issue in the GitHub mirror](https://github.com/jwplayer/wordpress-plugin/issues) of this plugin. Thank you for your help.**
+**BE AWARE: The plugin is in beta. We've tested it locally, but because of the myriad of different WordPress setups it could be possible that you run into issues. If you do run into an issue we encourage you to [report this issue in the GitHub mirror](https://github.com/jwplayer/wordpress-plugin/issues) of this plugin. Thank you for your help.**
 
-This plugin will give you the power to use videos, playlists, and players from your JW Player account within Wordpress. You will also be able to track the performance of your content with JW Player’s dashboard analytics.
+This plugin will give you the power to use videos, playlists, and players from your JW Player account within WordPress. You will also be able to track the performance of your content with JW Player’s dashboard analytics.
 
 
 = Key Features =
@@ -27,7 +27,7 @@ This plugin will give you the power to use videos, playlists, and players from y
     - Allow you to create or manage players or media objects from within the plugin (these actions happen within the JW Player dashboard)
 
 * Additional features:
-    - You may also sync Wordpress-hosted media to your JW Player account (as externally-hosted media)
+    - You may also sync WordPress-hosted media to your JW Player account (as externally-hosted media)
 
 [Sign up for a free JW Player account!](http://www.jwplayer.com/pricing/)
 
@@ -48,8 +48,8 @@ This plugin is open source and we strongly encourage users to contribute to the 
 == Installation ==
 
 1. Unpack the zip-file and put the resulting folder in the wp-content/plugins
-   directory of your Wordpress install.
-2. Login as Wordpress admin.
+   directory of your WordPress install.
+2. Login as WordPress admin.
 3. Go the the plugins page, the JW Player plugin should be visible.
    Click "activate" to enable the plugin.
 4. Click the "authorize plugin" link in the notification to authorize your
@@ -69,7 +69,7 @@ This plugin is open source and we strongly encourage users to contribute to the 
 
 == Frequently Asked Questions ==
 
-= Does this plugin replace the old JW Player Plugin for Wordpress? =
+= Does this plugin replace the old JW Player Plugin for WordPress? =
 
 Yes, it does. You cannot run both plugins at the same time. However, you can import your referenced media, your players and your playlists from the old plugin into your JW Player account.
 
@@ -116,5 +116,5 @@ That's great. Tell us about it and open a pull request on [our GitHub mirror of 
 
 == Upgrade Notice ==
 
-Please remember that this plugin replaces our old JW Platform and our old JW Player for Wordpress plugins and it should not be activated at the same time.
+Please remember that this plugin replaces our old JW Platform and our old JW Player for WordPress plugins and it should not be activated at the same time.
 


### PR DESCRIPTION
I fixed the majority of blockers that VIP would flag:
Sanitizing, escaping, code formatting standards, yoda conditions, serializing/unserializing data, type checking in arrays. 

But there are some that they will still flag, such as attempting to write (touch, file_put_contents) to the file system for error logging, and some functionality that is supposed to take place when the environment is not VIP. 

Since this is supposed to  be on VIP or wordpress.com, I recommend removing the error logging in util.php, and also remove the fallback (wp_remote_get)  in jwplayer-api.class.php

I’ve changed the many calls to serialize/unserialize, but there is one use of serialize that I couldn’t touch since it comes from the jwplayer server as serialized data and not json
https://vip.wordpress.com/documentation/code-review-what-we-look-for/#serializing-data

Need to remove any commented code and debug statements.

Please take a look at the git history if you have any questions as I commented on items as I fixed them, and linked to the relevant wordpress vip documentation.