### PR TITLE
Fix missing escaping in media.php

### DIFF
--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -21,8 +21,8 @@ function jwplayer_media_sync_form_html( $media ) {
 		$html .= 'Disabling sync is currently not possible, because it would break your media embeds. ';
 		$html .= '</p>';
 	} else {
-		$html .= "<label for='attachments[$media->ID][jwplayer_media_sync]'>";
-		$html .= "<input type='checkbox' value='sync' name='attachments[$media->ID][jwplayer_media_sync]' />";
+		$html .= "<label for='".esc_attr( 'attachments['.$media->ID.'][jwplayer_media_sync]').">'";
+		$html .= "<input type='checkbox' value='sync' name='".esc_attr( 'attachments['.$media->ID.'][jwplayer_media_sync]' )."' />";
 		$html .= '&nbsp;&nbsp;Sync to JW Player';
 		$html .= '</label>';
 		$html .= '<p class="description">';

--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -22,7 +22,7 @@ function jwplayer_media_sync_form_html( $media ) {
 		$html .= '</p>';
 	} else {
 		$html .= '<label for="'.esc_attr( 'attachments['.$media->ID.'][jwplayer_media_sync]').'">';
-		$html .= '<input type="checkbox" value="sync" name="'.esc_attr( 'attachments['.$media->ID.'][jwplayer_media_sync]' ).' />';
+		$html .= '<input type="checkbox" value="sync" name="'.esc_attr( 'attachments['.$media->ID.'][jwplayer_media_sync]' ).'" />';
 		$html .= '&nbsp;&nbsp;Sync to JW Player';
 		$html .= '</label>';
 		$html .= '<p class="description">';

--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -21,8 +21,8 @@ function jwplayer_media_sync_form_html( $media ) {
 		$html .= 'Disabling sync is currently not possible, because it would break your media embeds. ';
 		$html .= '</p>';
 	} else {
-		$html .= "<label for='".esc_attr( 'attachments['.$media->ID.'][jwplayer_media_sync]').">'";
-		$html .= "<input type='checkbox' value='sync' name='".esc_attr( 'attachments['.$media->ID.'][jwplayer_media_sync]' )."' />";
+		$html .= '<label for="'.esc_attr( 'attachments['.$media->ID.'][jwplayer_media_sync]').'">';
+		$html .= '<input type="checkbox" value="sync" name="'.esc_attr( 'attachments['.$media->ID.'][jwplayer_media_sync]' ).' />';
 		$html .= '&nbsp;&nbsp;Sync to JW Player';
 		$html .= '</label>';
 		$html .= '<p class="description">';


### PR DESCRIPTION
During a VIP review I found 4 unescaped variables embedded in double quoted strings, e.g. `echo "$variable";`. This should be avoided as it's not possible to escape inline this way. This PR fixes those 4 unescaped variables embedded in 2 strings via `esc_attr`