### PR TITLE
Change `jwplayer_media_menu` to always return

### DIFF
--- a/jw-player/include/media.php
+++ b/jw-player/include/media.php
@@ -135,6 +135,7 @@ function jwplayer_media_menu( $tabs ) {
 		$newtab = array( 'jwplayer' => 'JW Player' );
 		return array_merge( $tabs, $newtab );
 	}
+	return $tabs;
 }
 
 // output the contents of the JW Player tab in the "Add media" page


### PR DESCRIPTION
If the API Key option isn't set, `$tabs` gets set to `NULL` affecting other functions relying on that filter.