### PR TITLE
Increasing timeout used by vip_safe_wp_remote_get function to 3s

### DIFF
--- a/jw-player/include/jwplayer-api.class.php
+++ b/jw-player/include/jwplayer-api.class.php
@@ -85,7 +85,7 @@ class JWPlayer_api {
 
 		$response = null;
 		if ( 'wpvip' == $this->_library ) {
-			$response = vip_safe_wp_remote_get( $url );
+			$response = vip_safe_wp_remote_get( $url, '', 3, 3 );
 		} else {
 			$response = wp_remote_get( $url, array(
 				'timeout' => 15


### PR DESCRIPTION
The default timeout of the vip_safe_wp_remote_get function (1s) is not always enough for jwplayer's remote calls. This commit is increasing the timeout used by the function to 3s, which is the max value the function allows.